### PR TITLE
Custom Logger implementation

### DIFF
--- a/appdaemon/appapi.py
+++ b/appdaemon/appapi.py
@@ -7,6 +7,7 @@ import re
 import requests
 import inspect
 
+from appdaemon.logging import log_limit
 import appdaemon.homeassistant as ha
 
 
@@ -38,16 +39,6 @@ class AppDaemon:
         if service.find("/") == -1:
             raise ValueError("Invalid Service Name: {}".format(service))
 
-    def _sub_stack(self, msg):
-        stack = inspect.stack()
-        if msg.find("__module__") != -1:
-            msg = msg.replace("__module__", stack[2][1])
-        if msg.find("__line__") != -1:
-            msg = msg.replace("__line__", str(stack[2][2]))
-        if msg.find("__function__") != -1:
-            msg = msg.replace("__function__", stack[2][3])
-        return msg
-
     #
     # Utility
     #
@@ -59,12 +50,12 @@ class AppDaemon:
     def split_device_list(self, list_):
         return list_.split(",")
 
+    @log_limit
     def log(self, msg, level="INFO"):
-        msg = self._sub_stack(msg)
         ha.log(self._logger, level, msg, self.name)
 
+    @log_limit
     def error(self, msg, level="WARNING"):
-        msg = self._sub_stack(msg)
         ha.log(self._error, level, msg, self.name)
 
     def get_app(self, name):

--- a/appdaemon/conf.py
+++ b/appdaemon/conf.py
@@ -36,6 +36,7 @@ endtime = None
 interval = 1
 certpath = None
 
+logformat = None
 loglevel = "INFO"
 ha_config = None
 version = 0

--- a/appdaemon/homeassistant.py
+++ b/appdaemon/homeassistant.py
@@ -4,6 +4,8 @@ import datetime
 import re
 import random
 import uuid
+import logging
+from appdaemon.logging import log_limit
 
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
@@ -36,24 +38,10 @@ def _sanitize_kwargs(kwargs, keys):
     return kwargs
 
 
-def log(logger, level, msg, name=""):
-    levels = {
-        "CRITICAL": 50,
-        "ERROR": 40,
-        "WARNING": 30,
-        "INFO": 20,
-        "DEBUG": 10,
-        "NOTSET": 0
-    }
-    if name != "":
-        name = " {}:".format(name)
-
-    if conf.realtime:
-        timestamp = datetime.datetime.now()
-    else:
-        timestamp = get_now()
-
-    logger.log(levels[level], "{} {}{} {}".format(timestamp, level, name, msg))
+@log_limit
+def log(logger, level, msg, name="appdaemon"):
+    extra = {'appname': name}
+    logger.log(logging.getLevelName(level), msg, extra=extra)
 
 
 def get_now():

--- a/appdaemon/logging.py
+++ b/appdaemon/logging.py
@@ -1,0 +1,83 @@
+import io
+import traceback
+import logging
+import inspect
+import datetime
+from threading import local
+from functools import wraps
+
+
+class CallStackManager:
+
+    def __init__(self):
+        self._local = local()
+
+    @property
+    def call_stack(self):
+        if not hasattr(self._local, 'call_stack'):
+            self._local.call_stack = []
+        return self._local.call_stack
+
+    def __enter__(self):
+        frame = inspect.currentframe()
+        if frame is not None:
+            frame = frame.f_back.f_back
+        self.call_stack.append(frame)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.call_stack.pop()
+
+call_stack_manager = CallStackManager()
+
+
+class CallStackManagerLogger(logging.Logger):
+
+    def findCaller(self, stack_info=False):
+        call_stack = call_stack_manager.call_stack
+        if not call_stack:
+            return super().findCaller(stack_info)
+        f = call_stack[0]
+        if f is None:
+            return super().findCaller(stack_info)
+
+        co = f.f_code
+
+        sinfo = None
+        if stack_info:
+            sio = io.StringIO()
+            sio.write('Stack (most recent call last):\n')
+            traceback.print_stack(f, file=sio)
+            sinfo = sio.getvalue()
+            if sinfo[-1] == '\n':
+                sinfo = sinfo[:-1]
+            sio.close()
+
+        return co.co_filename, f.f_lineno, co.co_name, sinfo
+
+
+class CustomFormatter(logging.Formatter):
+
+    converter = datetime.datetime.fromtimestamp
+    default_time_format = '%Y-%m-%d %H:%M:%S.%f'
+
+    def __init__(self, fmt=None, datefmt=None, style='%', timestamp_conv=None):
+        super().__init__(fmt, datefmt, style)
+        if timestamp_conv:
+            self.converter = timestamp_conv
+
+    def formatTime(self, record, datefmt=None):
+        dt = self.converter(record.created)
+        if not datefmt:
+            datefmt = self.default_time_format
+        return dt.strftime(datefmt)
+
+
+def log_limit(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        with call_stack_manager:
+            return func(*args, **kwargs)
+    return wrapper
+
+
+logging.setLoggerClass(CallStackManagerLogger)


### PR DESCRIPTION
I've created a custom logger implementation which allows inserting correct line numbers, filenames and function names using `Formatter` instead of string substitution. Whole implementation is in new `appdaemon.logging` module.

Classes in the new module:

- `CallStackManager` - A helper class which allows recording a call stack. It implements a context management protocol and keeps a record as a thread local attribute. It is instantiated in the module as a global variable call_stack_manager.
- `CallStackManagerLogger` - A custom Logger class which uses call_stack_manager to retrieve correct frame to log caller info (file, line no and func name).
- `CustomFormatter` - it overrides time formatting to work in the same way as the current logging logic.

There's also a `log_limit` decorator, which is used on `homeassistant.log` function and both logging methods on `AppDaemon` class. The decorator registers log calls on the CallStackManager.

I've set the default format string to:
`%(asctime)s %(levelname)s %(appname)s %(message)s`
where:

- `%(asctime)s`, `%(levelname)s` and `%(message)s` are standard logger fields (asctime formatting is implemented in `CustomFormatter`)
- `%(message)s` contains only the message (no app name, time and level - those are in their own fields).
- `%(appname)s` is the name of the app (as it was before in the log message itself). If app name is not provided, it defaults to "appdaemon".

Custom format string can be changed by setting `logformat` setting in `[AppDaemon]` section in the config file. To get caller info, following fields can be added (those are standard field in python logging):

- `%(filename)s` - contains name of the file where log function was called from
- `%(funcName)s` - contains calling function name where the log function was called
- `%(lineno)d` - contains line number where the log function was called

An example format string containing these fields:

`%(asctime)s %(levelname)s %(appname)s [%(filename)s - %(funcName)s@%(lineno)d] %(message)s`

PS. This change removes current string replacement. Message should no longer contain `__module__`, `__line__` and `__function__` placeholders as they won't be replaced anymore.