### PR TITLE
Respect cert_path setting when connecting to WebSocket over SSL

### DIFF
--- a/appdaemon/appapi.py
+++ b/appdaemon/appapi.py
@@ -267,10 +267,10 @@ class AppDaemon:
             headers = {'x-ha-access': conf.ha_key}
         else:
             headers = {}
-        apiurl = "{}/api/events/{}".format(
-            conf.ha_url, event, verify=conf.certpath
+        apiurl = "{}/api/events/{}".format(conf.ha_url, event)
+        r = requests.post(
+            apiurl, headers=headers, json=kwargs, verify=conf.certpath
         )
-        r = requests.post(apiurl, headers=headers, json=kwargs)
         r.raise_for_status()
         return r.json()
 

--- a/appdaemon/appdaemon.py
+++ b/appdaemon/appdaemon.py
@@ -1358,7 +1358,12 @@ def run():
                 elif url.startswith('http://'):
                     url = url.replace('http', 'ws', 1)
 
-                ws = create_connection("{}/api/websocket".format(url))
+                sslopt = {}
+                if conf.certpath:
+                    sslopt['ca_certs'] = conf.certpath
+                ws = create_connection(
+                    "{}/api/websocket".format(url), sslopt=sslopt
+                )
                 result = json.loads(ws.recv())
                 ha.log(conf.logger, "INFO",
                        "Connected to Home Assistant {}".format(


### PR DESCRIPTION
When analysing an issue #41 I've found out that the WebSocket connection doesn't respect cert_path setting for self signed certificates. This PR fixes this.