### PR TITLE
Add config option cert_verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ logfile = STDOUT
 errorfile = STDERR
 threads = 10
 cert_path = <path/to/root/CA/cert>
+cert_verify = True
 # Apps
 [hello_world]
 module = hello
@@ -62,6 +63,7 @@ class = HelloWorld
 - `errorfile` (optional) is the name of the logfile for errors - this will usually be errors during compilation and execution of the apps. If `errorfile = STDERR` errors will be sent to stderr instead of a file, if not specified, output will be sent to STDERR.
 - `threads` - the number of dedicated worker threads to create for running the apps. Note, this will bear no resembelance to the number of apps you have, the threads are re-used and only active for as long as required to tun a particular callback or initialization, leave this set to 10 unless you experience thread starvation
 - `cert_path` (optional) - path to root CA cert directory - use only if you are using self signed certs.
+- `cert_verify` (optional) - flag for cert verification - set to `False` to disable verification on self signed erts.
 
 Optionally, you can place your apps in a directory other than under the config directory using the `app_dir` directive.
 

--- a/appdaemon/appdaemon.py
+++ b/appdaemon/appdaemon.py
@@ -1469,6 +1469,9 @@ def main():
     else:
         conf.dash_compile_on_start = False
 
+    if config['AppDaemon'].getboolean("cert_verify", True) == False:
+        conf.certpath = False
+
     if conf.dash_url is not None:
         conf.dashboard = True
         url = urlparse(conf.dash_url)


### PR DESCRIPTION
When using hard-coded IP addresses, HTTPS connection to Home Assistant *and* a self-signed certificate that is not issued for the hard-coded IP address, cert verification fails, even though a custom CA cert is provided via the `cert_path` config option.

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.4/site-packages/appdaemon/appdaemon.py", line 1576, in main
    ha_config = ha.get_ha_config()
  File "/usr/local/lib/python3.4/site-packages/appdaemon/homeassistant.py", line 233, in get_ha_config
    r = requests.get(apiurl, headers=headers, verify=conf.certpath)
  File "/usr/local/lib/python3.4/site-packages/requests/api.py", line 70, in get
    return request('get', url, params=params, **kwargs)
  File "/usr/local/lib/python3.4/site-packages/requests/api.py", line 56, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/local/lib/python3.4/site-packages/requests/sessions.py", line 488, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python3.4/site-packages/requests/sessions.py", line 609, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python3.4/site-packages/requests/adapters.py", line 497, in send
    raise SSLError(e, request=request)
requests.exceptions.SSLError: hostname '10.10.9.7' doesn't match 'homeassistant'
```

The added option `cert_verify = False` disables the `requests` certification validation altogether by setting `conf.certpath = False` (see [Advanced Usage documentaion of requests package](http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification).