### PR TITLE
Fixed bug where media title was not displayed

### DIFF
--- a/appdaemon/widgets/basemedia/basemedia.js
+++ b/appdaemon/widgets/basemedia/basemedia.js
@@ -159,7 +159,7 @@ function basemedia(widget_id, url, skin, parameters)
         {
             self.set_field(self, "album", state.attributes.media_album_name)
         }
-        if ("media_album_name" in state.attributes)
+        if ("media_title" in state.attributes)
         {
             if ("truncate_name" in self.parameters)
             {


### PR DESCRIPTION
Tested with mpd. The browser would receive the media_title attribute from HA, but would not display it. It seems the code was copy pasted and the attribute name was not changed. I can confirm that the widget now displays the correct media name.