### PR TITLE
Only read_apps() every 5s

### DIFF
--- a/appdaemon/appdaemon.py
+++ b/appdaemon/appdaemon.py
@@ -47,6 +47,7 @@ config_file_modified = 0
 config_file = ""
 was_dst = None
 last_state = None
+read_files_delay = 0
 reading_messages = False
 inits = {}
 stopping = False
@@ -449,6 +450,7 @@ def exec_schedule(name, entry, args):
 def do_every_second(utc):
     global was_dst
     global last_state
+    global read_files_delay
 
     # Lets check if we are connected, if not give up.
     if not reading_messages:
@@ -501,8 +503,10 @@ def do_every_second(utc):
 
         # Check to see if any apps have changed but only if we have valid state
 
-        if last_state is not None:
-            read_apps()
+        read_files_delay = read_files_delay + 1
+        if read_files_delay % 5 is 0:
+            if last_state is not None:
+                read_apps()
 
         # Check to see if config has changed
 


### PR DESCRIPTION
This came about because I added some dependencies between some apps, and my cpu load jumped 5%.  

The dependency checking looked complex, so I decided to try running it every 5s rather than every second, and top reported that appdaemon usage dropped from around 20% to 7%. 

The downside, of course, is that I have to wait up to 5s for the files to reload.  

I'm also not sure whether it should read the config file only when reading the apps.  Which may be irrelevant as I think the correct way of doing this may be to only create the dependencies every time the configuration file changes, but this was a quick and easy proof of concept.