### PR TITLE
Fix argument formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ $ appdaemon -c conf/appdaemon.cfg
 
 # AppDaemon arguments
 
+```
 usage: appdaemon [-h] [-c CONFIG] [-p PIDFILE] [-t TICK] [-s STARTTIME]
                  [-e ENDTIME] [-i INTERVAL]
                  [-D {DEBUG,INFO,WARNING,ERROR,CRITICAL}] [-v] [-d]
@@ -178,6 +179,7 @@ optional arguments:
                         debug level
   -v, --version         show program's version number and exit
   -d, --daemon          run as a background process
+```
 
 -c is the path to the configuration file. If not specified, AppDaemon will look for a file named `appdaemon.cfg` first in `~/.homeassistant` then in `/etc/appdaemon`. If the file is not specified and it is not found in either location, AppDaemon will raise an exception.                        
                         


### PR DESCRIPTION
The argument section looks fine in a text editor but does not render nicely in Markdown.  By wrapping that content with ` ``` ` we can display the text with a monospace font and no inner Markdown rendering.

Visual diff:

![image](https://user-images.githubusercontent.com/202034/27413116-51a0e562-56c7-11e7-913d-c517bfc0e525.png)
