### PR TITLE
dev

### DIFF
--- a/appdaemon/appdaemon.py
+++ b/appdaemon/appdaemon.py
@@ -1009,6 +1009,9 @@ def file_in_modules(file, modules):
 # noinspection PyBroadException
 def read_apps(all_=False):
     global config
+    # Check if the apps are disabled in config
+    if not conf.apps:
+        return
     found_files = []
     modules = []
     for root, subdirs, files in os.walk(conf.app_dir):


### PR DESCRIPTION
There were a few places where read_apps was called 
without checking if apps were disabled by config.
This led to Appdaemon continuously crashing and retrying
to connect to HASS when apps were disabled and 
Home Assistant was restarted.