### PR TITLE
Fix websocket to use wss when using https

### DIFF
--- a/appdaemon/assets/templates/dashinit.jinja2
+++ b/appdaemon/assets/templates/dashinit.jinja2
@@ -26,7 +26,7 @@ $(function(){ //DOM Ready
     {% endfor %}
     
     // Start listening for HA Events
-    if (location.protocol == 'https')
+    if (location.protocol == 'https:')
     {
         wsprot = "wss:"
     }


### PR DESCRIPTION
When using https, websocket was still using ws.  the location.protocol includes the colon so the comparison failed and defaulted to using ws.