### PR TITLE
Added persistent_notification support.

### DIFF
--- a/appdaemon/appdash.py
+++ b/appdaemon/appdash.py
@@ -37,6 +37,7 @@ def set_paths():
     conf.compiled_css_dir = os.path.join(conf.compile_dir, "css")
     conf.fonts_dir = os.path.join(conf.dash_dir, "assets", "fonts")
     conf.images_dir = os.path.join(conf.dash_dir, "assets", "images")
+    conf.sounds_dir = os.path.join(conf.dash_dir, "assets", "sounds")
     conf.base_url = "http://{}:{}".format(conf.dash_host, conf.dash_port)
     conf.stream_url = "ws://{}:{}/stream".format(conf.dash_host, conf.dash_port)
 
@@ -281,6 +282,8 @@ def setup_routes():
 
     # Add static path for images
     app.router.add_static('/images', conf.images_dir)
+
+    app.router.add_static('/sounds', conf.sounds_dir)
 
 
 # Setup

--- a/appdaemon/assets/javascript/dashboard.js
+++ b/appdaemon/assets/javascript/dashboard.js
@@ -123,6 +123,9 @@ var WidgetBase = function(widget_id, url, skin, parameters, monitored_entities, 
                             {
                                 child.ViewModel.title("entity not found: " + entity.entity);
                                 new_state = null
+                                if (entity.initial_with_null) {
+                                    entity.initial_with_null(child, new_state)
+                                }
                             }
                             else
                             {
@@ -198,15 +201,19 @@ var WidgetBase = function(widget_id, url, skin, parameters, monitored_entities, 
     clen = callbacks.length;
     for (i=0;i < clen;i++)
     {
-        $(callbacks[i].selector).click((
-            function(callback, ch, params)
+        var func = function(callback, ch, params)
+        {
+            return function()
             {
-                return function()
-                {
-                    callback(ch, params)
-                };
-            }(callbacks[i].callback, child,callbacks[i].parameters))
-        );
+                callback(ch, params)
+            };
+        }(callbacks[i].callback, child, callbacks[i].parameters);
+
+        if (callbacks[i].live) {
+            $(callbacks[i].selector[0]).on('click', callbacks[i].selector[1], func);
+        } else {
+            $(callbacks[i].selector).click(func);
+        }
     }
     
     // Create and initialize bindings

--- a/appdaemon/assets/templates/dashinit.jinja2
+++ b/appdaemon/assets/templates/dashinit.jinja2
@@ -14,8 +14,12 @@ $(function(){ //DOM Ready
     // Add Widgets
 
     var gridster = $(".gridster ul").gridster().data('gridster');
-    {% for widget in widgets%}
-        gridster.add_widget('<li><div data-bind="attr: {style: widget_style}" class="widget widget-{{widget.parameters.widget_type}}-{{widget.id}}" id="{{widget.id}}">{{widget.html}}</div></li>', {{widget.size[0]}}, {{widget.size[1]}}, {{widget.position[0]}}, {{widget.position[1]}})
+    {% for widget in widgets %}
+        {% if widget.parameters.gridless==1 %}
+            $('body').append('<div data-bind="visible: display, attr: {style: persistent_notification_style}" class="widget widget-{{widget.parameters.widget_type}} widget-{{widget.parameters.widget_type}}-{{widget.id}}" id="{{widget.id}}">{{widget.html}}</div>')
+        {% else %}
+            gridster.add_widget('<li><div data-bind="attr: {style: widget_style}" class="widget widget-{{widget.parameters.widget_type}}-{{widget.id}}" id="{{widget.id}}">{{widget.html}}</div></li>', {{widget.size[0]}}, {{widget.size[1]}}, {{widget.position[0]}}, {{widget.position[1]}})
+        {% endif %}
     {% endfor %}
     
     

--- a/appdaemon/dashboard.py
+++ b/appdaemon/dashboard.py
@@ -326,9 +326,9 @@ def add_layout(value, layout, occupied, dash, page, includes, css_vars, global_p
         while "{}x{}".format(column, layout) in occupied:
             column += 1
 
+        widget = {}
         if name != "spacer":
             sanitized_name = name.replace(".", "-").replace("_", "-").lower()
-            widget = {}
             widget["id"] = "{}-{}".format(page, sanitized_name)
 
             if widget_exists(dash["widgets"], widget["id"]):
@@ -338,7 +338,8 @@ def add_layout(value, layout, occupied, dash, page, includes, css_vars, global_p
                 widget["size"] = [xsize, ysize]
                 widget["parameters"] = load_widget(dash, includes, name, css_vars, global_parameters)
                 dash["widgets"].append(widget)
-        if "gridless" in widget["parameters"] and widget["parameters"]["gridless"]==1:
+
+        if "parameters" in widget and "gridless" in widget["parameters"] and widget["parameters"]["gridless"]==1:
             continue
 
         for x in range(column, column + int(xsize)):

--- a/appdaemon/dashboard.py
+++ b/appdaemon/dashboard.py
@@ -228,6 +228,8 @@ def load_widget(dash, includes, name, css_vars, global_parameters):
         #
         # Variable substitutions
         #
+        if "entity" in instantiated_widget:
+            instantiated_widget["short_entity"] = ".".join(instantiated_widget["entity"].split(".")[1:])
         yaml_file, templates = do_subs(yaml_path, instantiated_widget, '""')
 
         try:
@@ -336,6 +338,8 @@ def add_layout(value, layout, occupied, dash, page, includes, css_vars, global_p
                 widget["size"] = [xsize, ysize]
                 widget["parameters"] = load_widget(dash, includes, name, css_vars, global_parameters)
                 dash["widgets"].append(widget)
+        if "gridless" in widget["parameters"] and widget["parameters"]["gridless"]==1:
+            continue
 
         for x in range(column, column + int(xsize)):
             for y in range(layout, layout + int(ysize)):

--- a/appdaemon/widgets/basenotification/basenotification.css
+++ b/appdaemon/widgets/basenotification/basenotification.css
@@ -1,0 +1,30 @@
+.widget-basenotification-{{id}} {
+	position: fixed;
+	width: 90%;
+	height: 90%;
+	top: 5%;
+	left: 5%;
+	z-index: 4200;
+	background-color: #f00;
+	border: 1px solid white;
+	animation: pulse-basenotification-{{id}} 2s infinite;
+}
+
+@keyframes pulse-basenotification-{{id}} {
+	0% {
+		background-color: #f00;
+	}
+	50% {
+		background-color: #800;
+	}
+}
+
+.widget-basenotification-{{id}} .dismiss {
+	border: 2px solid white;
+	border-radius: 5px;
+	padding: 20px;
+	display: inline-block;
+	margin-top: 40px;
+	cursor: pointer;
+	font-size: 200%;
+}

--- a/appdaemon/widgets/basenotification/basenotification.html
+++ b/appdaemon/widgets/basenotification/basenotification.html
@@ -1,0 +1,3 @@
+<h1 class="title" data-bind="text: title, attr: {style: title_style}"></h1>
+<h1 class="state_text" data-bind="text: state_text, attr: {style: state_text_style}"></h1>
+<i class="dismiss">Dismiss</i>

--- a/appdaemon/widgets/basenotification/basenotification.js
+++ b/appdaemon/widgets/basenotification/basenotification.js
@@ -95,13 +95,16 @@ function basenotification(widget_id, url, skin, parameters)
         if (state!=null) {
             self.audio = new Audio("/sounds/tos-redalert.mp3");
             self.audio.addEventListener('ended', function() {
-                this.currentTime = 0;
-                this.play();
+                if (self.audio) {
+                    self.audio.currentTime = 0;
+                    self.audio.play();
+                }
             });
             self.audio.play();
         } else {
             if (self.audio) {
                 self.audio.pause();
+                self.audio = null;
             }
         }
 

--- a/appdaemon/widgets/basenotification/basenotification.js
+++ b/appdaemon/widgets/basenotification/basenotification.js
@@ -1,0 +1,109 @@
+function basenotification(widget_id, url, skin, parameters)
+{
+    // Will be using "self" throughout for the various flavors of "this"
+    // so for consistency ...
+
+    self = this
+
+    // Initialization
+
+    self.widget_id = widget_id
+
+    // Store on brightness or fallback to a default
+
+    // Parameters may come in useful later on
+
+    self.parameters = parameters
+
+    // Define callbacks for on click events
+    // They are defined as functions below and can be any name as long as the
+    // 'self'variables match the callbacks array below
+    // We need to add them into the object for later reference
+
+    self.OnButtonClick = OnButtonClick
+
+    var callbacks =
+        [
+            {"selector": ['#' + widget_id, '.dismiss'], "callback": self.OnButtonClick, "live": true},
+        ]
+
+    // Define callbacks for entities - this model allows a widget to monitor multiple entities if needed
+    // Initial will be called when the dashboard loads and state has been gathered for the entity
+    // Update will be called every time an update occurs for that entity
+
+    self.OnStateAvailable = OnStateAvailable
+    self.OnStateUpdate = OnStateUpdate
+
+    self.entity_state = {}
+
+    var monitored_entities =
+        [
+            {"entity": parameters.entity, "initial": self.OnStateAvailable, "update": self.OnStateUpdate, "initial_with_null": self.OnStateAvailable}
+        ]
+
+    // Finally, call the parent constructor to get things moving
+
+    WidgetBase.call(self, widget_id, url, skin, parameters, monitored_entities, callbacks)
+
+    // Function Definitions
+
+    // The StateAvailable function will be called when
+    // self.state[<entity>] has valid information for the requested entity
+    // state is the initial state
+
+    function OnStateAvailable(self, state)
+    {
+        self.state = state;
+        set_view(self, self.state)
+    }
+
+    // The OnStateUpdate function will be called when the specific entity
+    // receives a state update - it's new values will be available
+    // in self.state[<entity>] and returned in the state parameter
+
+    function OnStateUpdate(self, state)
+    {
+        self.state = state;
+        set_view(self, self.state)
+    }
+
+    function OnButtonClick(self)
+    {
+        self.call_service(self, self.parameters.post_service_dismiss)
+        set_view(self, null)
+    }
+
+    // Set view is a helper function to set all aspects of the widget to its
+    // current state - it is called by widget code when an update occurs
+    // or some other event that requires a an update of the view
+
+    function set_view(self, state, level)
+    {
+        self.set_field(self, "display", state!=null);
+
+        if (state != null && "state" in state) {
+            self.set_field(self, "state_text", state.state);
+        } else {
+            self.set_field(self, "state_text", null);
+        }
+        if (state != null && "attributes" in state && "title" in state.attributes) {
+            self.set_field(self, "title", state.attributes.title);
+        } else {
+            self.set_field(self, "title", null);
+        }
+
+        if (state!=null) {
+            self.audio = new Audio("/sounds/tos-redalert.mp3");
+            self.audio.addEventListener('ended', function() {
+                this.currentTime = 0;
+                this.play();
+            });
+            self.audio.play();
+        } else {
+            if (self.audio) {
+                self.audio.pause();
+            }
+        }
+
+    }
+}

--- a/appdaemon/widgets/persistent_notification.yaml
+++ b/appdaemon/widgets/persistent_notification.yaml
@@ -1,0 +1,21 @@
+widget_type: basenotification
+entity: {{entity}}
+post_service_dismiss:
+  service: persistent_notification/dismiss
+  notification_id: {{short_entity}}
+enable: 0
+gridless: 1
+fields:
+  title: {{title}}
+  title2: {{title2}}
+  display: "false"
+  icon: ""
+  icon_style: ""
+  state_text: ""
+icons: []
+static_icons: []
+css: []
+static_css:
+  title_style: "font-size: 500%; color: white;"
+  state_text_style: "font-size: 400%; color: white;"
+  persistent_notification_style: "display: none;"


### PR DESCRIPTION
Hi.

I've added support for persistent_notifications to the current version of AppDaemon / HADashboard.

<img width="1173" alt="bildschirmfoto 2017-07-15 um 12 52 50" src="https://user-images.githubusercontent.com/810163/28238830-91691988-695c-11e7-99d4-625a1546303f.png">

So far, this is working but pretty work-in-progress. But I had to make a few changes to the core of AppDaemon and would like to get a bit of feedback on this. If that feedback is positive, I will continue to work on polishing this PR. So, to be clear, I do not expect this Pull Request to be merged. (But if you want to, feel free to do it.)

What I changed in the core:
* Widgets can be "gridless" by setting "gridless: 1" in their YAML file. This means they won't take (or get) any space in the grid and will instead be placed at the bottom of `body` - initially hidden, in the most cases.
* Added a path `/sounds` to the router in order to be able to provide sound files for the browser to play.
* Widgets can have a callback `initial_with_null`. This behaves more or less like `initial` except that `initial_with_null` will be called with `null` if the entity doesn't exist at dashboard start. This may be the case with `persistent_notifications`, because they don't have to be declared before use.
* Callback for clicks on Widgets now support a parameter `live`, which will use jQuery's `.on` function for setting the `click` handler. This is necessary for attaching those events to hidden elements.
* A widget will not only have `entity` set, but also `short_entity`, which is the `entity` without the domain. (`persistent_notification.alert` will be `short_entity: alert`.)

To use / test:
* Checkout the code.
* Add a sound file as `/appdaemon/assets/sounds/tos-redalert.mp3`. Guess which sound file I used. ;-) For copyright reasons, I didn't include that file in that commit.
* Add a `persistent_notification` to the layout of a dashboard. For example, adding `persistent_notification.alert` somewhere. (Doesn't matter where in the output, it won't appear in the grid after all.)
* Fire a persistent_notification. For example by using "Services" in the "Developer Tool" of Home Assistant and then sending "Domain: persistent_notification", "Service: create" and "Service Data: `{"notification_id":"alert", "title":"Notification", "message":"This is a test notification."}`".

If you have any questions, feel free to ask me.

Oh, and, by the way, thanks for this great tool.