### PR TITLE
use pip3 instead of pip for upgrading

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -322,7 +322,7 @@ following command to update your copy:
 
 .. code:: bash
 
-    $ sudo pip install --upgrade appdaemon
+    $ sudo pip3 install --upgrade appdaemon
 
 If you are using docker, refer to the steps in the tutorial.
 


### PR DESCRIPTION
If you run two different python version on for example PI u need to do: sudo pip3 install --upgrade appdaemon. Please change this in documentation.

Thanks!

Hope I'm not wrong with this change :P