### PR TITLE
Dashboard: don't use absolute base_url

### DIFF
--- a/appdaemon/appdash.py
+++ b/appdaemon/appdash.py
@@ -37,7 +37,7 @@ def set_paths():
     conf.compiled_css_dir = os.path.join(conf.compile_dir, "css")
     conf.fonts_dir = os.path.join(conf.dash_dir, "assets", "fonts")
     conf.images_dir = os.path.join(conf.dash_dir, "assets", "images")
-    conf.base_url = "http://{}:{}".format(conf.dash_host, conf.dash_port)
+    conf.base_url = ""
     conf.stream_url = "ws://{}:{}/stream".format(conf.dash_host, conf.dash_port)
 
 

--- a/appdaemon/appdash.py
+++ b/appdaemon/appdash.py
@@ -38,7 +38,6 @@ def set_paths():
     conf.fonts_dir = os.path.join(conf.dash_dir, "assets", "fonts")
     conf.images_dir = os.path.join(conf.dash_dir, "assets", "images")
     conf.base_url = ""
-    conf.stream_url = "ws://{}:{}/stream".format(conf.dash_host, conf.dash_port)
 
 
 # Views
@@ -49,7 +48,7 @@ def set_paths():
 def list_dash(request):
     completed, pending = yield from asyncio.wait([conf.loop.run_in_executor(conf.executor, dashboard.list_dashes)])
     dash_list = list(completed)[0].result()
-    params = {"dash_list": dash_list, "stream_url": conf.stream_url}
+    params = {"dash_list": dash_list}
     params["main"] = "1"
     return params
 

--- a/appdaemon/conf.py
+++ b/appdaemon/conf.py
@@ -84,7 +84,6 @@ css_dir = None
 fonts_dir = None
 images_dir = None
 base_url = None
-stream_url = None
 state_url = None
 max_include_depth = 10
 dash_force_compile = False

--- a/appdaemon/dashboard.py
+++ b/appdaemon/dashboard.py
@@ -515,7 +515,6 @@ def compile_dash(name, skin, skindir, params):
         return {"errors": ["Dashboard has errors or is not found - check log for details"], "dash_list": dash_list}
 
     params = dash
-    params["stream_url"] = conf.stream_url
     params["base_url"] = conf.base_url
     params["name"] = name.lower()
     params["skin"] = skin


### PR DESCRIPTION
When I run dashboard behind proxy, application does not work because it uses bind address that is not accessible. When we don't set absolute base_url, we don't need to set additional configuration to get it working anywhere.