### PR TITLE
Update API.md: bugfix list example

### DIFF
--- a/API.md
+++ b/API.md
@@ -156,7 +156,7 @@ entities:
 Which can be accessed as a list in python with:
 
 ```python
-for entity in self.args.entities:
+for entity in self.args['entities']:
   do some stuff
 ```
 


### PR DESCRIPTION
corrected the specified list example - have to use self.args['entities'] and not self.args.entities