### PR TITLE
Add example apps for bysykkel, yr, ical, ruter, eventCache and eventMonitor

### DIFF
--- a/conf/example_apps/bysykkel.py
+++ b/conf/example_apps/bysykkel.py
@@ -1,0 +1,45 @@
+import appdaemon.appapi as appapi
+import requests
+import json
+from datetime import datetime
+
+"""
+
+Get availability for Oslo City Bikes
+
+Arguments:
+ - event: Entity name when publishing event
+ - interval: Update interval, in minutes
+
+"""
+class Bysykkel(appapi.AppDaemon):
+    def initialize(self):
+        self.apiUrl = "http://reisapi.ruter.no"
+        self.entity = self.args['event']
+
+        now = datetime.now()
+        interval = int(self.args['interval'])
+
+        self.run_every(self.updateState, now, interval * 60)
+
+    def fetch(self, path):
+        res = requests.get(self.apiUrl + path)
+        return json.loads(res.text)
+
+    def updateState(self, kwargs=None):
+        status = self.getStatus()
+        self.set_app_state(self.entity, {
+            'state': "",
+            'attributes': status
+        })
+
+    def getStatus(self):
+        stations = self.fetch("/Place/GetCityBikeStations?latmin={lat_min}&latmax={lat_max}&longmin={long_min}&longmax={long_max}".format(**self.args))
+
+        return [{
+            'title': s['Title'],
+            'subtitle': s['Subtitle'],
+            'bikes': s['Availability']['Bikes'],
+            'locks': s['Availability']['Locks'],
+        } for s in stations]
+

--- a/conf/example_apps/eventCache.py
+++ b/conf/example_apps/eventCache.py
@@ -1,0 +1,75 @@
+import appdaemon.appapi as appapi
+import os
+import json
+
+"""
+
+Enable caching of appdaemon events.
+
+You would probably NOT want to use this for HomeAssistant events.
+
+The reason you would use this is probably because you're using custom events in
+some other appdaemon app, and want this event to be available (typically for
+hadashboard) before the app has been able to publish a fresh event.
+
+Simply put, you list up events you want to monitor, and every time this event
+is published, it is persisted to disk. When this app is restarted (probably
+because of a restart of appdaemon), it will publish all monitored events at
+startup.
+
+Arguments:
+ - cache: Location, on disk, where the events are stored
+ - evnets: List of events to monitor, and later publish
+
+"""
+class Cache(appapi.AppDaemon):
+    def initialize(self):
+        self.cache = self.args['cache']
+        self.events = self.args['events']
+
+        self.state = self.loadCache()
+        self.deprecateOldEvents()
+
+        self.publishCache()
+
+        for event in self.events:
+            self.log('watching event "{}" for state changes'.format(event))
+            self.listen_state(self.changed, event)
+
+    def loadCache(self):
+        if not os.path.exists(self.cache):
+            with open(self.cache, mode="w") as f:
+                json.dump({}, f)
+
+        with open(self.cache) as f:
+            try:
+                return json.load(f)
+            except:
+                return {}
+
+    def saveCache(self):
+        try:
+            with open(self.cache, mode="w") as f:
+                json.dump(self.state, f)
+        except:
+            self.log('oops during save of cache')
+
+
+    def deprecateOldEvents(self):
+        deprecatedEvents = [e for e in self.state if e not in self.events]
+        for deprecated in deprecatedEvents:
+            del self.state[deprecated]
+
+    def publishCache(self):
+        for event in self.events:
+            if event in self.state:
+                self.set_app_state(event, self.state[event])
+                self.log('published event: ' + event)
+            else:
+                self.log('event not in cache: ' + event)
+
+    def changed(self, entity, attribute, old, new, kwargs):
+        value = self.get_state(entity, 'all')
+        self.state[entity] = value
+        self.saveCache()
+

--- a/conf/example_apps/eventMonitor.py
+++ b/conf/example_apps/eventMonitor.py
@@ -1,0 +1,24 @@
+import appdaemon.appapi as appapi
+
+"""
+
+Monitor events and output changes to the log. Nice for debugging purposes.
+
+Arguments:
+ - events: List of events to monitor
+
+"""
+class Monitor(appapi.AppDaemon):
+    def initialize(self):
+        events = self.args['events']
+
+        for event in events:
+            self.changed(event, None, None, None, None)
+
+            self.log('watching event "{}" for state changes'.format(event))
+            self.listen_state(self.changed, event)
+
+    def changed(self, entity, attribute, old, new, kwargs):
+        value = self.get_state(entity, 'all')
+        self.log(entity + ': ' + str(value))
+

--- a/conf/example_apps/ical.py
+++ b/conf/example_apps/ical.py
@@ -1,0 +1,52 @@
+import appdaemon.appapi as appapi
+import requests
+import ics
+import arrow
+from datetime import datetime, timedelta
+
+"""
+
+Load and publish iCal data, e.g a Google Calendar feed
+
+NB: This app need the "ics" Python module.
+
+Arguments:
+ - event: Entity name when publishing event
+ - interval: Update interval, in minutes
+ - feed: Feed url
+ - max_days: Maximum number of days to include
+ - max_events: Maximum number of calendar events to include
+
+"""
+class Calendar(appapi.AppDaemon):
+    def initialize(self):
+        self.feed = self.args['feed']
+        self.entity = self.args['event']
+        self.max_events = int(self.args['max_events'])
+        self.max_days = int(self.args['max_days'])
+        interval = int(self.args['interval'])
+
+        inOneMinute = datetime.now() + timedelta(minutes = 1)
+        self.run_every(self.updateState, inOneMinute, interval * 60)
+
+    def updateState(self, kwargs=None):
+        self.log('loading data from ical feed')
+        data = requests.get(self.feed).text
+        ical = ics.Calendar(data)
+        self.log('ical data loaded')
+
+        now = arrow.now()
+        future = arrow.now().replace(days=self.max_days)
+
+        events = [{
+            'name': e.name,
+            'location': e.location,
+            'begin': e.begin.isoformat(),
+            'end': e.end.isoformat(),
+        } for e in ical.events if e.begin > now and e.begin < future][:self.max_events]
+
+        self.set_app_state(self.entity, {
+            'state': "",
+            'attributes': events
+        })
+

--- a/conf/example_apps/ruter.py
+++ b/conf/example_apps/ruter.py
@@ -1,0 +1,69 @@
+import appdaemon.appapi as appapi
+import requests
+import json
+from datetime import datetime
+
+"""
+
+Get travel info for Oslo public transport
+
+Arguments:
+ - event: Entity name when publishing event
+ - departues: Number of departures to publish for eatch line
+ - interval: Update interval, in minutes
+ - x_min, x_max, y_min, y_max: Box coordinates for area to find stops in, in the UTM coordinate system
+
+"""
+class Ruter(appapi.AppDaemon):
+    def initialize(self):
+        self.apiUrl = "http://reisapi.ruter.no"
+        self.departures = self.args['departures']
+        self.entity = self.args['event']
+
+        now = datetime.now()
+        interval = int(self.args['interval'])
+
+        self.run_every(self.updateState, now, interval * 60)
+
+    def fetch(self, path):
+        res = requests.get(self.apiUrl + path)
+        return json.loads(res.text)
+
+    def updateState(self, kwargs=None):
+        departures = self.getDepartures()
+        self.set_app_state(self.entity, {
+            'state': "",
+            'attributes': departures
+        })
+
+    def getDepartures(self):
+        ruter = {}
+        stops = self.fetch("/Place/GetStopsByArea?xmin={x_min}&xmax={x_max}&ymin={y_min}&ymax={y_max}".format(**self.args))
+
+        for stop in stops:
+            name = stop['Name']
+            if not name in ruter:
+                ruter[name] = {}
+
+            departures = self.fetch("/StopVisit/GetDepartures/{}".format(stop['ID']))
+            for departure in departures:
+                info = departure["MonitoredVehicleJourney"]
+                line = info["PublishedLineName"] + " " + info["DestinationName"]
+                platform = info["MonitoredCall"]["DeparturePlatformName"]
+
+                if not platform in ruter[name]:
+                    ruter[name][platform] = {}
+
+                if not line in ruter[name][platform]:
+                    ruter[name][platform][line] = []
+
+                if len(ruter[name][platform][line]) < self.departures:
+                    ruter[name][platform][line].append({
+                        'time': info["MonitoredCall"]["ExpectedArrivalTime"],
+                        'monitored': info["Monitored"],
+                    })
+
+        return ruter
+
+
+

--- a/conf/example_apps/yr.py
+++ b/conf/example_apps/yr.py
@@ -1,0 +1,63 @@
+import appdaemon.appapi as appapi
+import requests
+import xml.etree.ElementTree as ET
+from datetime import datetime, timedelta
+
+"""
+
+Get detailed Yr weather data
+
+Arguments:
+ - event: Entity name when publishing event
+ - interval: Update interval, in minutes. Must be at least 10
+ - source: Yr xml source
+ - hours: Number of hours to forecast, at most 48
+
+"""
+
+disclaimer = "Weather forecast from Yr, delivered by the Norwegian Meteorological Institute and NRK"
+user_agent = "HomeAssistant/Appdaemon Python/requests"
+
+class Yr(appapi.AppDaemon):
+    def initialize(self):
+        self.url = self.args['source']
+        self.entity = self.args['event']
+        self.hours = self.args['hours']
+
+        inOneMinute = datetime.now() + timedelta(minutes = 1)
+        interval = int(self.args['interval'])
+
+        if interval < 10:
+            raise Exception('Update interval ({}) must be at least 10 minutes'.format(interval))
+
+        # delay first launch with one minute, run every 'interval' minutes
+        self.run_every(self.updateState, inOneMinute, interval * 60)
+
+    def updateState(self, kwargs):
+        forecast = self.fetchForecast()
+        self.set_app_state(self.entity, {
+            'state': "",
+            'attributes': forecast
+        })
+
+    def fetchData(self):
+        res = requests.get(self.url, headers={ 'User-Agent': user_agent })
+        return res.text
+
+    def fetchForecast(self):
+        data = self.fetchData()
+        root = ET.fromstring(data)
+        periods = root.find('.//tabular')
+        return {
+            'disclaimer': disclaimer,
+            'forecast': [{
+                'from': x.get('from'),
+                'to': x.get('to'),
+                'weather': x.find('symbol').get('name'),
+                'symbol': x.find('symbol').get('var'),
+                'precip': x.find('precipitation').get('value'),
+                'windSpeed': x.find('windSpeed').get('mps'),
+                'windDirection': x.find('windDirection').get('deg'),
+                'temp': x.find('temperature').get('value')
+            } for x in periods[:self.hours]],
+        }


### PR DESCRIPTION
These apps are all a bit more "Hadashboard" centric than the other
examples. These apps are ported, or inspired by "jobs" used in the old
ruby version of Hadashboard.

They do not interact with Home Assistant at all, instead they fetch data
from external sources and publish them as Appdaemon events. These events
are are then consumed in dashboard widgets. Because we fetch and
tranform data in the apps, the widgets themselves will be pretty simple,
and simply format data, as it would any other Home Assistant event.

Apps:
 - bysykkel: Status of Oslo City Bikes
 - ical: Events from iCal feed. Perferct for Google Calendar .ics-feed
 - ruter: Oslo public transport real time data
 - yr: Detailed weather reports from Yr (more fine grained forecast than
   Home Assistant currenly have)
 - eventCache: Caching of events, to make dashboards behave better
   before data is loaded
 - eventMonitor: Debugging of events