### PR TITLE
Added sticky flag to navigate component

### DIFF
--- a/appdaemon/assets/javascript/dashboard.js
+++ b/appdaemon/assets/javascript/dashboard.js
@@ -36,7 +36,16 @@ function ha_status(stream, dash, widgets)
                     {
                         ret = location.pathname
                     }
-                    timeout_params += "timeout=" + timeout + "&return=" + ret;
+                    if ("sticky")
+                    {
+                        sticky = data.data.sticky;
+                    }
+                    else
+                    {
+                        sticky = 0;
+                    }
+
+                    timeout_params += "timeout=" + timeout + "&return=" + ret + "&sticky=" + sticky;
                 }
                 window.location.href = data.data.target + location.search + timeout_params;
             }

--- a/appdaemon/assets/templates/dashinit.jinja2
+++ b/appdaemon/assets/templates/dashinit.jinja2
@@ -35,11 +35,17 @@ $(function(){ //DOM Ready
 
     $( ".gridster" ).click(function(){
         clearTimeout(myTimeout);
+        if (myTimeoutSticky) {
+            myTimeout = setTimeout(function() { navigate(myTimeoutUrl); }, myTimeoutDelay);
+        }
     });
 
     // Set up timeout
 
-    var myTimeout
+    var myTimeout;
+    var myTimeoutUrl;
+    var myTimeoutDelay;
+    var myTimeoutSticky = 0;
 
     if (location.search != "")
     {
@@ -56,7 +62,7 @@ $(function(){ //DOM Ready
             argcount = 0
             for (arg in result)
             {
-                if (arg != "timeout" && arg != "return")
+                if (arg != "timeout" && arg != "return" && arg != "sticky")
                 {
                     if (argcount == 0)
                     {
@@ -70,6 +76,12 @@ $(function(){ //DOM Ready
                     url += arg + "=" + result[arg]
                 }
             }
+            if ("sticky" in result)
+            {
+                myTimeoutSticky = (result.sticky == "1");
+            }
+            myTimeoutUrl = url;
+            myTimeoutDelay = result.timeout * 1000;
             myTimeout = setTimeout(function() { navigate(url); }, result.timeout * 1000);
         }
     }


### PR DESCRIPTION
Added a stycky flag that will make the dashboard always return to the
dashboard in the args after a period of inactivity. Clicking the
dashboard resets (not cancels) the timeout. This is useful if you want a
main dashboard that the user always returns to after not using the
dashboard for a while.

Setting the sticky flag to 0 or omitting it will cause the default
timeout behaviour: to cancel the timeout when the user clicks something.

Example usage

```
args:
  timeout: 10
  sticky: 1
  return: main
```