### PR TITLE
Add widgt_style_active and widget_style_inactive css variables

### DIFF
--- a/appdaemon/assets/css/default/variables.yaml
+++ b/appdaemon/assets/css/default/variables.yaml
@@ -238,6 +238,8 @@ light_unit_style:  "color: $white"
 light_level_up_style: "color: $gray_light"
 light_level_down_style: "color: $gray_light"
 light_widget_style: $background_style
+light_widget_style_active: $background_style
+light_widget_style_inactive: $background_style
 
 input_slider_icon_up: fa-plus
 input_slider_icon_down: fa-minus

--- a/appdaemon/assets/css/default/variables.yaml
+++ b/appdaemon/assets/css/default/variables.yaml
@@ -84,6 +84,8 @@ scene_icon_style_inactive: $style_inactive
 scene_title_style: $style_title
 scene_title2_style: $style_title2
 scene_widget_style: $background_style
+scene_widget_style_active: $background_style
+scene_widget_style_inactive: $background_style
 scene_state_text_style: "color: $white"
 
 mode_icon_on: fa-arrows-alt
@@ -93,6 +95,8 @@ mode_icon_style_inactive: $style_inactive
 mode_title_style: $style_title
 mode_title2_style: $style_title2
 mode_widget_style: $background_style
+mode_widget_style_active: $background_style
+mode_widget_style_inactive: $background_style
 mode_state_text_style: "color: $white"
 
 script_icon_on: fa-th-large
@@ -102,6 +106,8 @@ script_icon_style_inactive: $style_inactive
 script_title_style: $style_title
 script_title2_style: $style_title2
 script_widget_style: $background_style
+script_widget_style_active: $background_style
+script_widget_style_inactive: $background_style
 script_state_text_style: "color: $white"
 
 binary_sensor_icon_on: fa-bullseye
@@ -111,6 +117,8 @@ binary_sensor_icon_style_inactive: $style_inactive
 binary_sensor_title_style: $style_title
 binary_sensor_title2_style: $style_title2
 binary_sensor_widget_style: $background_style
+binary_sensor_widget_style_active: $background_style
+binary_sensor_widget_style_inactive: $background_style
 binary_sensor_state_text_style: "color: $white"
 
 device_tracker_icon_on: fa-user
@@ -120,6 +128,8 @@ device_tracker_icon_style_inactive: $style_inactive
 device_tracker_title_style: $style_title
 device_tracker_title2_style: $style_title2
 device_tracker_widget_style: $background_style
+device_tracker_widget_style_active: $background_style
+device_tracker_widget_style_inactive: $background_style
 device_tracker_state_text_style: "color: $white"
 
 input_boolean_icon_on: fa-sliders
@@ -129,6 +139,8 @@ input_boolean_icon_style_inactive: $style_inactive
 input_boolean_title_style: $style_title
 input_boolean_title2_style: $style_title2
 input_boolean_widget_style: $background_style
+input_boolean_widget_style_active: $background_style
+input_boolean_widget_style_inactive: $background_style
 input_boolean_state_text_style: "color: $white"
 
 switch_icon_on: fa-circle
@@ -138,6 +150,8 @@ switch_icon_style_inactive: $style_inactive
 switch_title_style: $style_title
 switch_title2_style: $style_title2
 switch_widget_style: $background_style
+switch_widget_style_active: $background_style
+switch_widget_style_inactive: $background_style
 switch_state_text_style: "color: $white"
 
 lock_icon_on: fa-unlock-alt
@@ -147,6 +161,8 @@ lock_icon_style_inactive: $style_inactive
 lock_title_style: $style_title
 lock_title2_style: $style_title2
 lock_widget_style: $background_style
+lock_widget_style_active: $background_style
+lock_widget_style_inactive: $background_style
 lock_state_text_style: "color: $white"
 
 cover_icon_on: fa-arrows-v
@@ -156,6 +172,8 @@ cover_icon_style_inactive: $style_inactive
 cover_title_style: $style_title
 cover_title2_style: $style_title2
 cover_widget_style: $background_style
+cover_widget_style_active: $background_style
+cover_widget_style_inactive: $background_style
 cover_state_text_style: "color: $white"
 
 clock_date_style: "color: $white"
@@ -192,6 +210,8 @@ reload_icon_inactive_style: "color: $white"
 reload_title_style: $style_title
 reload_title2_style: $style_title2
 reload_widget_style: $background_style
+reload_widget_style_active: $background_style
+reload_widget_style_inactive: $background_style
 
 navigate_icon_active: fa-spinner fa-spin
 navigate_icon_inactive: fa-gear
@@ -200,6 +220,8 @@ navigate_icon_inactive_style: "color: $white"
 navigate_title_style: $style_title
 navigate_title2_style: $style_title2
 navigate_widget_style: $background_style
+navigate_widget_style_active: $background_style
+navigate_widget_style_inactive: $background_style
 
 
 media_player_icon_play: fa-play
@@ -218,6 +240,8 @@ media_player_level_style: "color: $white"
 media_player_level_up_style: "color: $gray_light"
 media_player_level_down_style: "color: $gray_light"
 media_player_widget_style: $background_style
+media_player_widget_style_active: $background_style
+media_player_widget_style_inactive: $background_style
 media_player_icon_previous: fa-step-backward
 media_player_icon_next: fa-step-forward
 media_player_icon_style_previous: "color: $gray_light"
@@ -276,6 +300,8 @@ group_level_style: "color: $white"
 group_level_up_style: "color: $gray_light"
 group_level_down_style: "color: $gray_light"
 group_widget_style: $background_style
+group_widget_style_active: $background_style
+group_widget_style_inactive: $background_style
 group_unit_style: "color: $white"
 
 iframe_title_style: "$style_title; background-color: rgba(0, 0, 0, 0.5)"
@@ -337,6 +363,8 @@ light_with_brightness_title_style: $style_title
 light_with_brightness_title2_style: $style_title2
 light_with_brightness_slider_style: ""
 light_with_brightness_widget_style: $background_style
+light_with_brightness_widget_style_active: $background_style
+light_with_brightness_widget_style_inactive: $background_style
 light_with_brightness_icon_style_active: $style_active
 light_with_brightness_icon_style_inactive: $style_inactive
 
@@ -346,6 +374,8 @@ light_with_colorpicker_title_style: $style_title
 light_with_colorpicker_title2_style: $style_title2
 light_with_colorpicker_button_style: ""
 light_with_colorpicker_widget_style: $background_style
+light_with_colorpicker_widget_style_active: $background_style
+light_with_colorpicker_widget_style_inactive: $background_style
 light_with_colorpicker_icon_style_active: $style_active
 light_with_colorpicker_icon_style_inactive: $style_inactive
 
@@ -361,3 +391,5 @@ heater_slider_style: ""
 heater_widget_style: $background_style
 heater_icon_style_active: $style_active
 heater_icon_style_inactive: $style_inactive
+heater_widget_style_active: $background_style
+heater_widget_style_inactive: $background_style

--- a/appdaemon/assets/css/glassic/variables.yaml
+++ b/appdaemon/assets/css/glassic/variables.yaml
@@ -89,6 +89,8 @@ scene_icon_style_inactive: $style_inactive
 scene_title_style: $style_title
 scene_title2_style: $style_title2
 scene_widget_style: $background_style
+scene_widget_style_active: $background_style
+scene_widget_style_inactive: $background_style
 scene_state_text_style: "color: white"
 
 mode_icon_on: fa-arrows-alt
@@ -98,6 +100,8 @@ mode_icon_style_inactive: $style_inactive
 mode_title_style: $style_title
 mode_title2_style: $style_title2
 mode_widget_style: $background_style
+mode_widget_style_active: $background_style
+mode_widget_style_inactive: $background_style
 mode_state_text_style: "color: white"
 
 script_icon_on: fa-th-large
@@ -107,6 +111,8 @@ script_icon_style_inactive: $style_inactive
 script_title_style: $style_title
 script_title2_style: $style_title2
 script_widget_style: $background_style
+script_widget_style_active: $background_style
+script_widget_style_inactive: $background_style
 script_state_text_style: "color: white"
 
 binary_sensor_icon_on: fa-bullseye
@@ -116,6 +122,8 @@ binary_sensor_icon_style_inactive: $style_inactive
 binary_sensor_title_style: $style_title
 binary_sensor_title2_style: $style_title2
 binary_sensor_widget_style: $background_style
+binary_sensor_widget_style_active: $background_style
+binary_sensor_widget_style_inactive: $background_style
 binary_sensor_state_text_style: "color: white"
 
 device_tracker_icon_on: fa-user
@@ -125,6 +133,8 @@ device_tracker_icon_style_inactive: $style_inactive
 device_tracker_title_style: $style_title
 device_tracker_title2_style: $style_title2
 device_tracker_widget_style: $background_style
+device_tracker_widget_style_active: $background_style
+device_tracker_widget_style_inactive: $background_style
 device_tracker_state_text_style: "color: white"
 
 input_boolean_icon_on: fa-sliders
@@ -134,6 +144,8 @@ input_boolean_icon_style_inactive: $style_inactive
 input_boolean_title_style: $style_title
 input_boolean_title2_style: $style_title2
 input_boolean_widget_style: $background_style
+input_boolean_widget_style_active: $background_style
+input_boolean_widget_style_inactive: $background_style
 input_boolean_state_text_style: "color: white"
 
 switch_icon_on: fa-circle
@@ -143,6 +155,8 @@ switch_icon_style_inactive: $style_inactive
 switch_title_style: $style_title
 switch_title2_style: $style_title2
 switch_widget_style: $background_style
+switch_widget_style_active: $background_style
+switch_widget_style_inactive: $background_style
 switch_state_text_style: "color: white"
 
 lock_icon_on: fa-unlock-alt
@@ -152,6 +166,8 @@ lock_icon_style_inactive: $style_inactive
 lock_title_style: $style_title
 lock_title2_style: $style_title2
 lock_widget_style: $background_style
+lock_widget_style_active: $background_style
+lock_widget_style_inactive: $background_style
 lock_state_text_style: "color: white"
 
 cover_icon_on: fa-arrows-v
@@ -161,6 +177,8 @@ cover_icon_style_inactive: $style_inactive
 cover_title_style: $style_title
 cover_title2_style: $style_title2
 cover_widget_style: $background_style
+cover_widget_style_active: $background_style
+cover_widget_style_inactive: $background_style
 cover_state_text_style: "color: white"
 
 clock_date_style: "color: $white; font-weight: 700; font-size: 175%"
@@ -192,6 +210,8 @@ reload_title2_style: $style_title2
 reload_icon_active_style: $style_active
 reload_icon_inactive_style: "line-height: 90%; color: #3B5957; text-shadow: 0px 1px 0px rgba(255,255,255,.3), 0px -1px 0px rgba(0,0,0,.7); font-weight: bold; text-shadow: 0px 1px 0px rgba(255,255,255,.3), 0px -1px 0px rgba(0,0,0,.7)"
 reload_widget_style: $background_style
+reload_widget_style_active: $background_style
+reload_widget_style_inactive: $background_style
 
 navigate_icon_active: fa-spinner fa-spin
 navigate_icon_inactive: fa-gear
@@ -200,6 +220,8 @@ navigate_title2_style: $style_title2
 navigate_icon_active_style: $style_active
 navigate_icon_inactive_style: "line-height: 90%; color: #3B5957; text-shadow: 0px 1px 0px rgba(255,255,255,.3), 0px -1px 0px rgba(0,0,0,.7); font-weight: bold; text-shadow: 0px 1px 0px rgba(255,255,255,.3), 0px -1px 0px rgba(0,0,0,.7)"
 navigate_widget_style: $background_style
+navigate_widget_style_active: $background_style
+navigate_widget_style_inactive: $background_style
 
 media_player_icon_play: fa-play
 media_player_icon_pause: fa-pause
@@ -218,6 +240,8 @@ media_player_level_style: "color: $gray_light"
 media_player_level_up_style: "color: $gray_light"
 media_player_level_down_style: "color: $gray_light"
 media_player_widget_style: $background_style
+media_player_widget_style_active: $background_style
+media_player_widget_style_inactive: $background_style
 media_player_icon_previous: fa-step-backward
 media_player_icon_next: fa-step-forward
 media_player_icon_style_previous: "color: $white"
@@ -277,6 +301,8 @@ group_level_style: "color: $gray_light"
 group_level_up_style: "color: $gray_light"
 group_level_down_style: "color: $gray_light"
 group_widget_style: $background_style
+group_widget_style_active: $background_style
+group_widget_style_inactive: $background_style
 group_unit_style: "color: $gray_light"
 
 iframe_title_style: "$style_title; background-color: rgba(0, 0, 0, 0.5)"
@@ -338,6 +364,8 @@ light_with_brightness_title_style: $style_title
 light_with_brightness_title2_style: $style_title2
 light_with_brightness_slider_style: ""
 light_with_brightness_widget_style: $background_style
+light_with_brightness_widget_style_active: $background_style
+light_with_brightness_widget_style_inactive: $background_style
 light_with_brightness_icon_style_active: $style_active
 light_with_brightness_icon_style_inactive: $style_inactive
 
@@ -347,6 +375,8 @@ light_with_colorpicker_title_style: $style_title
 light_with_colorpicker_title2_style: $style_title2
 light_with_colorpicker_button_style: ""
 light_with_colorpicker_widget_style: $background_style
+light_with_colorpicker_widget_style_active: $background_style
+light_with_colorpicker_widget_style_inactive: $background_style
 light_with_colorpicker_icon_style_active: $style_active
 light_with_colorpicker_icon_style_inactive: $style_inactive
 
@@ -360,5 +390,7 @@ heater_title_style: $style_title
 heater_title2_style: $style_title2
 heater_slider_style: ""
 heater_widget_style: $background_style
+heater_widget_style_active: $background_style
+heater_widget_style_inactive: $background_style
 heater_icon_style_active: $style_active
 heater_icon_style_inactive: $style_inactive

--- a/appdaemon/assets/css/glassic/variables.yaml
+++ b/appdaemon/assets/css/glassic/variables.yaml
@@ -237,6 +237,8 @@ light_level_style: "color: $gray_light"
 light_level_up_style: "color: $gray_light"
 light_level_down_style: "color: $gray_light"
 light_widget_style: $background_style
+light_widget_style_active: $background_style
+light_widget_style_inactive: $background_style
 light_unit_style:  "color: $gray_light"
 
 input_slider_icon_up: fa-plus

--- a/appdaemon/assets/css/obsidian/variables.yaml
+++ b/appdaemon/assets/css/obsidian/variables.yaml
@@ -91,6 +91,8 @@ scene_icon_style_inactive: $style_inactive
 scene_title_style: $style_title
 scene_title2_style: $style_title2
 scene_widget_style: $background_style
+scene_widget_style_active: $background_style
+scene_widget_style_inactive: $background_style
 scene_state_text_style: $style_info
 
 mode_icon_on: fa-arrows-alt
@@ -100,6 +102,8 @@ mode_icon_style_inactive: $style_inactive
 mode_title_style: $style_title
 mode_title2_style: $style_title2
 mode_widget_style: $background_style
+mode_widget_style_active: $background_style
+mode_widget_style_inactive: $background_style
 mode_state_text_style: $style_info
 
 script_icon_on: fa-th-large
@@ -109,6 +113,8 @@ script_icon_style_inactive: $style_inactive
 script_title_style: $style_title
 script_title2_style: $style_title2
 script_widget_style: $background_style
+script_widget_style_active: $background_style
+script_widget_style_inactive: $background_style
 script_state_text_style: $style_info
 
 binary_sensor_icon_on: fa-bullseye fa-spin
@@ -118,6 +124,8 @@ binary_sensor_icon_style_inactive: $style_inactive
 binary_sensor_title_style: $style_title
 binary_sensor_title2_style: $style_title2
 binary_sensor_widget_style: $background_style
+binary_sensor_widget_style_active: $background_style
+binary_sensor_widget_style_inactive: $background_style
 binary_sensor_state_text_style: $style_info
 
 device_tracker_icon_on: fa-user
@@ -127,6 +135,8 @@ device_tracker_icon_style_inactive: $style_inactive
 device_tracker_title_style: $style_title
 device_tracker_title2_style: $style_title2
 device_tracker_widget_style: $background_style
+device_tracker_widget_style_active: $background_style
+device_tracker_widget_style_inactive: $background_style
 device_tracker_state_text_style: $style_info
 
 input_boolean_icon_on: fa-sliders
@@ -136,6 +146,8 @@ input_boolean_icon_style_inactive: $style_inactive
 input_boolean_title_style: $style_title
 input_boolean_title2_style: $style_title2
 input_boolean_widget_style: $background_style
+input_boolean_widget_style_active: $background_style
+input_boolean_widget_style_inactive: $background_style
 input_boolean_state_text_style: $style_info
 
 switch_icon_on: fa-circle
@@ -145,6 +157,8 @@ switch_icon_style_inactive: $style_inactive
 switch_title_style: $style_title
 switch_title2_style: $style_title2
 switch_widget_style: $background_style
+switch_widget_style_active: $background_style
+switch_widget_style_inactive: $background_style
 switch_state_text_style: $style_info
 
 lock_icon_on: fa-unlock-alt
@@ -154,6 +168,8 @@ lock_icon_style_inactive: $style_inactive
 lock_title_style: $style_title
 lock_title2_style: $style_title2
 lock_widget_style: $background_style
+lock_widget_style_active: $background_style
+lock_widget_style_inactive: $background_style
 lock_state_text_style: $style_info
 
 cover_icon_on: fa-arrows-v
@@ -163,6 +179,8 @@ cover_icon_style_inactive: $style_inactive
 cover_title_style: $style_title
 cover_title2_style: $style_title2
 cover_widget_style: $background_style
+cover_widget_style_active: $background_style
+cover_widget_style_inactive: $background_style
 cover_state_text_style: $style_info
 
 clock_date_style: "color: $white; font-size: 150%"
@@ -194,6 +212,8 @@ reload_icon_inactive_style: "color: $white"
 reload_title_style: "color: $white"
 reload_title2_style: $style_title2
 reload_widget_style: $background_style
+reload_widget_style_active: $background_style
+reload_widget_style_inactive: $background_style
 
 navigate_icon_active: fa-spinner fa-spin
 navigate_icon_inactive: fa-gear
@@ -202,6 +222,8 @@ navigate_icon_inactive_style: $style_active
 navigate_title_style: $style_title
 navigate_title2_style: $style_title2
 navigate_widget_style: $no_texture
+navigate_widget_style_active: $background_style
+navigate_widget_style_inactive: $background_style
 
 media_player_icon_play: fa-play
 media_player_icon_pause: fa-pause
@@ -220,6 +242,8 @@ media_player_level_style: "color: $white"
 media_player_level_up_style: "color: $gray_light"
 media_player_level_down_style: "color: $gray_light"
 media_player_widget_style: $background_style
+media_player_widget_style_active: $background_style
+media_player_widget_style_inactive: $background_style
 media_player_icon_previous: fa-step-backward
 media_player_icon_next: fa-step-forward
 media_player_icon_style_previous: "color: $gray_light"
@@ -278,6 +302,8 @@ group_level_style: "$style_inactive"
 group_level_up_style: "$style_inactive"
 group_level_down_style: "$style_inactive"
 group_widget_style: $background_style
+group_widget_style_active: $background_style
+group_widget_style_inactive: $background_style
 group_unit_style: "$style_inactive"
 
 iframe_title_style: "$style_title; background-color: rgba(0, 0, 0, 0.5)"
@@ -339,6 +365,8 @@ light_with_brightness_title_style: $style_title
 light_with_brightness_title2_style: $style_title2
 light_with_brightness_slider_style: ""
 light_with_brightness_widget_style: $background_style
+light_with_brightness_widget_style_active: $background_style
+light_with_brightness_widget_style_inactive: $background_style
 light_with_brightness_icon_style_active: $style_active
 light_with_brightness_icon_style_inactive: $style_inactive
 
@@ -348,6 +376,8 @@ light_with_colorpicker_title_style: $style_title
 light_with_colorpicker_title2_style: $style_title2
 light_with_colorpicker_button_style: ""
 light_with_colorpicker_widget_style: $background_style
+light_with_colorpicker_widget_style_active: $background_style
+light_with_colorpicker_widget_style_inactive: $background_style
 light_with_colorpicker_icon_style_active: $style_active
 light_with_colorpicker_icon_style_inactive: $style_inactive
 
@@ -361,5 +391,7 @@ heater_title_style: $style_title
 heater_title2_style: $style_title2
 heater_slider_style: ""
 heater_widget_style: $background_style
+heater_widget_style_active: $background_style
+heater_widget_style_inactive: $background_style
 heater_icon_style_active: $style_active
 heater_icon_style_inactive: $style_inactive

--- a/appdaemon/assets/css/obsidian/variables.yaml
+++ b/appdaemon/assets/css/obsidian/variables.yaml
@@ -238,6 +238,8 @@ light_level_style: $style_inactive
 light_level_up_style: $style_inactive
 light_level_down_style: $style_inactive
 light_widget_style: $background_style
+light_widget_style_active: $background_style
+light_widget_style_inactive: $background_style
 light_unit_style:  $style_inactive
 
 input_slider_icon_up: fa-plus

--- a/appdaemon/assets/css/simplyred/variables.yaml
+++ b/appdaemon/assets/css/simplyred/variables.yaml
@@ -250,6 +250,8 @@ light_level_style: "color: $gray_light"
 light_level_up_style: "color: $gray_light"
 light_level_down_style: "color: $gray_light"
 light_widget_style: $background_style
+light_widget_style_active: $background_style
+light_widget_style_inactive: $background_style
 light_unit_style: "color: $gray_light"
 
 input_slider_icon_up: fa-plus

--- a/appdaemon/assets/css/simplyred/variables.yaml
+++ b/appdaemon/assets/css/simplyred/variables.yaml
@@ -103,6 +103,8 @@ scene_icon_style_inactive: $style_inactive
 scene_title_style: $style_title
 scene_title2_style: $style_title2
 scene_widget_style: $background_style
+scene_widget_style_active: $background_style
+scene_widget_style_inactive: $background_style
 scene_state_text_style: "color: white; font-weight: bold"
 
 mode_icon_on: fa-arrows-alt
@@ -112,6 +114,8 @@ mode_icon_style_inactive: $style_inactive
 mode_title_style: $style_title
 mode_title2_style: $style_title2
 mode_widget_style: $background_style
+mode_widget_style_active: $background_style
+mode_widget_style_inactive: $background_style
 mode_state_text_style: "color: white; font-weight: bold"
 
 script_icon_on: fa-th-large
@@ -121,6 +125,8 @@ script_icon_style_inactive: $style_inactive
 script_title_style: $style_title
 script_title2_style: $style_title2
 script_widget_style: $background_style
+script_widget_style_active: $background_style
+script_widget_style_inactive: $background_style
 script_state_text_style: "color: white; font-weight: bold"
 
 binary_sensor_icon_on: fa-bullseye
@@ -130,6 +136,8 @@ binary_sensor_icon_style_inactive: $style_inactive
 binary_sensor_title_style: $style_title
 binary_sensor_title2_style: $style_title2
 binary_sensor_widget_style: $background_style
+binary_sensor_widget_style_active: $background_style
+binary_sensor_widget_style_inactive: $background_style
 binary_sensor_state_text_style: "color: white; font-weight: bold"
 
 device_tracker_icon_on: fa-user
@@ -140,6 +148,8 @@ device_tracker_title_style: $style_title
 device_tracker_title2_style: $style_title2
 device_tracker_state_text_style: "color: white; font-weight: bold"
 device_tracker_widget_style: $background_style
+device_tracker_widget_style_active: $background_style
+device_tracker_widget_style_inactive: $background_style
 
 input_boolean_icon_on: fa-sliders
 input_boolean_icon_off: fa-sliders
@@ -148,6 +158,8 @@ input_boolean_icon_style_inactive: $style_inactive
 input_boolean_title_style: $style_title
 input_boolean_title2_style: $style_title2
 input_boolean_widget_style: $background_style
+input_boolean_widget_style_active: $background_style
+input_boolean_widget_style_inactive: $background_style
 input_boolean_state_text_style: "color: white; font-weight: bold"
 
 switch_icon_on: fa-circle
@@ -157,6 +169,8 @@ switch_icon_style_inactive: $style_inactive
 switch_title_style: $style_title
 switch_title2_style: $style_title2
 switch_widget_style: $background_style
+switch_widget_style_active: $background_style
+switch_widget_style_inactive: $background_style
 switch_state_text_style: "color: white; font-weight: bold"
 
 lock_icon_on: fa-unlock-alt
@@ -166,6 +180,8 @@ lock_icon_style_inactive: $style_inactive
 lock_title_style: $style_title
 lock_title2_style: $style_title2
 lock_widget_style: $background_style
+lock_widget_style_active: $background_style
+lock_widget_style_inactive: $background_style
 lock_state_text_style: "color: white; font-weight: bold"
 
 cover_icon_on: fa-arrows-v
@@ -175,6 +191,8 @@ cover_icon_style_inactive: $style_inactive
 cover_title_style: $style_title
 cover_title2_style: $style_title2
 cover_widget_style: $background_style
+cover_widget_style_active: $background_style
+cover_widget_style_inactive: $background_style
 cover_state_text_style: "color: white; font-weight: bold"
 
 clock_date_style: "$textblur; font-weight: 900; font-style: bold"
@@ -206,6 +224,8 @@ reload_icon_inactive_style: $style_active
 reload_title_style: $style_title
 reload_title2_style: $style_title2
 reload_widget_style: $background_style
+reload_widget_style_active: $background_style
+reload_widget_style_inactive: $background_style
 
 navigate_icon_active: fa-spinner fa-spin
 navigate_icon_inactive: fa-gear
@@ -214,6 +234,8 @@ navigate_icon_inactive_style: $style_active
 navigate_title_style: $style_title
 navigate_title2_style: $style_title2
 navigate_widget_style: $background_style
+navigate_widget_style_active: $background_style
+navigate_widget_style_inactive: $background_style
 
 media_player_icon_play: fa-play
 media_player_icon_pause: fa-pause
@@ -232,6 +254,8 @@ media_player_level_style: "color: $white"
 media_player_level_up_style: "color: $gray_light"
 media_player_level_down_style: "color: $gray_light"
 media_player_widget_style: $background_style
+media_player_widget_style_active: $background_style
+media_player_widget_style_inactive: $background_style
 media_player_icon_previous: fa-step-backward
 media_player_icon_next: fa-step-forward
 media_player_icon_style_previous: "color: $gray_light"
@@ -290,6 +314,8 @@ group_level_style: "color: $gray_light"
 group_level_up_style: "color: $gray_light"
 group_level_down_style: "color: $gray_light"
 group_widget_style: $background_style
+group_widget_style_active: $background_style
+group_widget_style_inactive: $background_style
 group_unit_style: "color: $gray_light"
 
 iframe_title_style: "$style_title; background-color: rgba(0, 0, 0, 0.5)"
@@ -351,6 +377,8 @@ light_with_brightness_title_style: $style_title
 light_with_brightness_title2_style: $style_title2
 light_with_brightness_slider_style: ""
 light_with_brightness_widget_style: $background_style
+light_with_brightness_widget_style_active: $background_style
+light_with_brightness_widget_style_inactive: $background_style
 light_with_brightness_icon_style_active: $style_active
 light_with_brightness_icon_style_inactive: $style_inactive
 
@@ -360,6 +388,8 @@ light_with_colorpicker_title_style: $style_title
 light_with_colorpicker_title2_style: $style_title2
 light_with_colorpicker_button_style: ""
 light_with_colorpicker_widget_style: $background_style
+light_with_colorpicker_widget_style_active: $background_style
+light_with_colorpicker_widget_style_inactive: $background_style
 light_with_colorpicker_icon_style_active: $style_active
 light_with_colorpicker_icon_style_inactive: $style_inactive
 
@@ -373,5 +403,7 @@ heater_title_style: $style_title
 heater_title2_style: $style_title2
 heater_slider_style: ""
 heater_widget_style: $background_style
+heater_widget_style_active: $background_style
+heater_widget_style_inactive: $background_style
 heater_icon_style_active: $style_active
 heater_icon_style_inactive: $style_inactive

--- a/appdaemon/assets/css/zen/variables.yaml
+++ b/appdaemon/assets/css/zen/variables.yaml
@@ -254,6 +254,8 @@ light_level_style: "color: $gray_light"
 light_level_up_style: "color: $red"
 light_level_down_style: "color: $black"
 light_widget_style: $background_style
+light_widget_style_active: $background_style
+light_widget_style_inactive: $background_style
 light_unit_style: "color: $gray_light"
 
 input_slider_icon_up: fa-plus

--- a/appdaemon/assets/css/zen/variables.yaml
+++ b/appdaemon/assets/css/zen/variables.yaml
@@ -107,6 +107,8 @@ scene_icon_style_inactive: $style_inactive
 scene_title_style: $style_title
 scene_title2_style: $style_title2
 scene_widget_style: $background_style
+scene_widget_style_active: $background_style
+scene_widget_style_inactive: $background_style
 scene_state_text_style: "color: red; font-weight: bold"
 
 mode_icon_on: fa-arrows-alt
@@ -116,6 +118,8 @@ mode_icon_style_inactive: $style_inactive
 mode_title_style: $style_title
 mode_title2_style: $style_title2
 mode_widget_style: $background_style
+mode_widget_style_active: $background_style
+mode_widget_style_inactive: $background_style
 mode_state_text_style: "color: red; font-weight: bold"
 
 script_icon_on: fa-th-large
@@ -125,6 +129,8 @@ script_icon_style_inactive: $style_inactive
 script_title_style: $style_title
 script_title2_style: $style_title2
 script_widget_style: $background_style
+script_widget_style_active: $background_style
+script_widget_style_inactive: $background_style
 script_state_text_style: "color: $red; font-weight: bold"
 
 binary_sensor_icon_on: fa-spinner fa-pulse 
@@ -134,6 +140,8 @@ binary_sensor_icon_style_inactive: $style_inactive
 binary_sensor_title_style: $style_title
 binary_sensor_title2_style: $style_title2
 binary_sensor_widget_style: $background_style
+binary_sensor_widget_style_active: $background_style
+binary_sensor_widget_style_inactive: $background_style
 binary_sensor_state_text_style: "color: $red; font-weight: bold"
 
 device_tracker_icon_on: fa-user
@@ -143,6 +151,8 @@ device_tracker_icon_style_inactive: $style_inactive
 device_tracker_title_style: $style_title
 device_tracker_title2_style: $style_title2
 device_tracker_widget_style: $background_style
+device_tracker_widget_style_active: $background_style
+device_tracker_widget_style_inactive: $background_style
 device_tracker_state_text_style: "color: $red; font-weight: bold"
 
 input_boolean_icon_on: fa-sliders
@@ -152,6 +162,8 @@ input_boolean_icon_style_inactive: $style_inactive
 input_boolean_title_style: $style_title
 input_boolean_title2_style: $style_title2
 input_boolean_widget_style: $background_style
+input_boolean_widget_style_active: $background_style
+input_boolean_widget_style_inactive: $background_style
 input_boolean_state_text_style: "color: $red; font-weight: bold"
 
 switch_icon_on: fa-circle-o-notch fa-spin 
@@ -161,6 +173,8 @@ switch_icon_style_inactive: $style_inactive
 switch_title_style: $style_title
 switch_title2_style: $style_title2
 switch_widget_style: $background_style
+switch_widget_style_active: $background_style
+switch_widget_style_inactive: $background_style
 switch_state_text_style: "color: $red; font-weight: bold"
 
 lock_icon_on: fa-unlock-alt
@@ -170,6 +184,8 @@ lock_icon_style_inactive: $style_inactive
 lock_title_style: $style_title
 lock_title2_style: $style_title2
 lock_widget_style: $background_style
+lock_widget_style_active: $background_style
+lock_widget_style_inactive: $background_style
 lock_state_text_style: "color: $red; font-weight: bold"
 
 cover_icon_on: fa-arrows-v
@@ -179,6 +195,8 @@ cover_icon_style_inactive: $style_inactive
 cover_title_style: $style_title
 cover_title2_style: $style_title2
 cover_widget_style: $background_style
+cover_widget_style_active: $background_style
+cover_widget_style_inactive: $background_style
 cover_state_text_style: "color: $red; font-weight: bold"
 
 clock_date_style: "color: $white"
@@ -210,6 +228,8 @@ reload_icon_inactive_style: $style_active
 reload_title_style: "color: white"
 reload_title2_style: $style_title2
 reload_widget_style: $background_style
+reload_widget_style_active: $background_style
+reload_widget_style_inactive: $background_style
 
 navigate_icon_active: fa-spinner fa-spin
 navigate_icon_inactive: fa-gear
@@ -218,6 +238,8 @@ navigate_icon_inactive_style: $style_active
 navigate_title_style: "color: white"
 navigate_title2_style: "color: white"
 navigate_widget_style: $background_style
+navigate_widget_style_active: $background_style
+navigate_widget_style_inactive: $background_style
 
 media_player_icon_play: fa-play
 media_player_icon_pause: fa-pause
@@ -236,6 +258,8 @@ media_player_level_style: "color: $gray_light"
 media_player_level_up_style: "color: $red"
 media_player_level_down_style: "color: $black"
 media_player_widget_style: $transparent_black1
+media_player_widget_style_active: $background_style
+media_player_widget_style_inactive: $background_style
 media_player_icon_previous: fa-step-backward
 media_player_icon_next: fa-step-forward
 media_player_icon_style_previous: $style_inactive
@@ -294,6 +318,8 @@ group_level_style: "color: $gray_light"
 group_level_up_style: "color: $gray_light"
 group_level_down_style: "color: $gray_light"
 group_widget_style: $background_style
+group_widget_style_active: $background_style
+group_widget_style_inactive: $background_style
 group_unit_style: "color: $gray_light"
 
 iframe_title_style: "$style_title; background-color: rgba(255, 255, 255, 0.5)"
@@ -355,6 +381,8 @@ light_with_brightness_title_style: $style_title
 light_with_brightness_title2_style: $style_title2
 light_with_brightness_slider_style: ""
 light_with_brightness_widget_style: $background_style
+light_with_brightness_widget_style_active: $background_style
+light_with_brightness_widget_style_inactive: $background_style
 light_with_brightness_icon_style_active: $style_active
 light_with_brightness_icon_style_inactive: $style_inactive
 
@@ -364,6 +392,8 @@ light_with_colorpicker_title_style: $style_title
 light_with_colorpicker_title2_style: $style_title2
 light_with_colorpicker_button_style: ""
 light_with_colorpicker_widget_style: $background_style
+light_with_colorpicker_widget_style_active: $background_style
+light_with_colorpicker_widget_style_inactive: $background_style
 light_with_colorpicker_icon_style_active: $style_active
 light_with_colorpicker_icon_style_inactive: $style_inactive
 
@@ -377,5 +407,7 @@ heater_title_style: $style_title
 heater_title2_style: $style_title2
 heater_slider_style: ""
 heater_widget_style: $background_style
+heater_widget_style_active: $background_style
+heater_widget_style_inactive: $background_style
 heater_icon_style_active: $style_active
 heater_icon_style_inactive: $style_inactive

--- a/appdaemon/widgets/base_light_with_brightness/base_light_with_brightness.js
+++ b/appdaemon/widgets/base_light_with_brightness/base_light_with_brightness.js
@@ -177,11 +177,13 @@ function base_light_with_brightness(widget_id, url, skin, parameters)
             self.set_icon(self, "icon", self.icons.icon_on)
             // Set view will set the view for the appropriate field
             self.set_field(self, "icon_style", self.css.icon_style_active)
+            self.set_field(self, "widget_style", self.css.widget_style_active)
         }
         else
         {
             self.set_icon(self, "icon", self.icons.icon_off)
             self.set_field(self, "icon_style", self.css.icon_style_inactive)
+            self.set_field(self, "widget_style", self.css.widget_style_inactive)
         }
         if (typeof brightness == 'undefined')
         {

--- a/appdaemon/widgets/base_light_with_colorpicker/base_light_with_colorpicker.js
+++ b/appdaemon/widgets/base_light_with_colorpicker/base_light_with_colorpicker.js
@@ -150,11 +150,13 @@ function base_light_with_colorpicker(widget_id, url, skin, parameters)
             self.set_icon(self, "icon", self.icons.icon_on)
             // Set view will set the view for the appropriate field
             self.set_field(self, "icon_style", self.css.icon_style_active)
+            self.set_field(self, "widget_style", self.css.widget_style_active)
         }
         else
         {
             self.set_icon(self, "icon", self.icons.icon_off)
             self.set_field(self, "icon_style", self.css.icon_style_inactive)
+            self.set_field(self, "widget_style", self.css.widget_style_inactive)
         }
         if (typeof  rgb_color != 'undefined')
         {

--- a/appdaemon/widgets/baseheater/baseheater.js
+++ b/appdaemon/widgets/baseheater/baseheater.js
@@ -129,11 +129,13 @@ function baseheater(widget_id, url, skin, parameters)
         {
             self.set_icon(self, "icon", self.icons.icon_on)
             self.set_field(self, "icon_style", self.css.icon_style_active)
+            self.set_field(self, "widget_style", self.css.widget_style_active)
         }
         else
         {
             self.set_icon(self, "icon", self.icons.icon_off)
             self.set_field(self, "icon_style", self.css.icon_style_inactive)
+            self.set_field(self, "widget_style", self.css.widget_style_inactive)
         }
     }
 

--- a/appdaemon/widgets/baselight/baselight.js
+++ b/appdaemon/widgets/baselight/baselight.js
@@ -185,11 +185,13 @@ function baselight(widget_id, url, skin, parameters)
             self.set_icon(self, "icon", self.icons.icon_on)
             // Set view will set the view for the appropriate field
             self.set_field(self, "icon_style", self.css.icon_style_active)
+            self.set_field(self, "widget_style", self.css.widget_style_active)
         }
         else
         {
             self.set_icon(self, "icon", self.icons.icon_off)
             self.set_field(self, "icon_style", self.css.icon_style_inactive)
+            self.set_field(self, "widget_style", self.css.widget_style_inactive)
         }
         if (typeof level == 'undefined')
         {

--- a/appdaemon/widgets/basemedia/basemedia.js
+++ b/appdaemon/widgets/basemedia/basemedia.js
@@ -182,11 +182,13 @@ function basemedia(widget_id, url, skin, parameters)
         if (state.state === "playing")
         {
             self.set_field(self, "play_icon_style", self.css.icon_style_active)
+            self.set_field(self, "widget_style", self.css.widget_style_active)
             self.set_icon(self, "play_icon", self.icons.pause_icon)
         }
         else
         {
             self.set_field(self, "play_icon_style", self.css.icon_style_inactive)
+            self.set_field(self, "widget_style", self.css.widget_style_inactive)
             self.set_icon(self, "play_icon", self.icons.play_icon)
         }
 

--- a/appdaemon/widgets/baseswitch/baseswitch.js
+++ b/appdaemon/widgets/baseswitch/baseswitch.js
@@ -119,11 +119,13 @@ function baseswitch(widget_id, url, skin, parameters)
         {
             self.set_icon(self, "icon", self.icons.icon_on)
             self.set_field(self, "icon_style", self.css.icon_style_active)
+            self.set_field(self, "widget_style", self.css.widget_style_active)
         }
         else
         {
             self.set_icon(self, "icon", self.icons.icon_off)
             self.set_field(self, "icon_style", self.css.icon_style_inactive)
+            self.set_field(self, "widget_style", self.css.widget_style_inactive)
         }
         if ("state_text" in self.parameters && self.parameters.state_text == 1)
         {

--- a/appdaemon/widgets/binary_sensor.yaml
+++ b/appdaemon/widgets/binary_sensor.yaml
@@ -21,4 +21,6 @@ static_css:
   title2_style: $binary_sensor_title2_style
   state_text_style: $binary_sensor_state_text_style
   widget_style: $binary_sensor_widget_style
+  widget_style_active: $binary_sensor_widget_style_active
+  widget_style_inactive: $binary_sensor_widget_style_inactive
 

--- a/appdaemon/widgets/cover.yaml
+++ b/appdaemon/widgets/cover.yaml
@@ -27,3 +27,5 @@ static_css:
   title2_style: $cover_title2_style
   state_text_style: $cover_state_text_style
   widget_style: $cover_widget_style
+  widget_style_active: $cover_widget_style_active
+  widget_style_inactive: $cover_widget_style_inactive

--- a/appdaemon/widgets/device_tracker.yaml
+++ b/appdaemon/widgets/device_tracker.yaml
@@ -30,6 +30,8 @@ static_css:
   title2_style: $device_tracker_title2_style
   state_text_style: $device_tracker_state_text_style
   widget_style: $device_tracker_widget_style
+  widget_style_active: $device_tracker_widget_style_active
+  widget_style_inactive: $device_tracker_widget_style_inactive
 state_map:
     home: HOME
     not_home: AWAY

--- a/appdaemon/widgets/group.yaml
+++ b/appdaemon/widgets/group.yaml
@@ -32,3 +32,5 @@ static_css:
 css:
   icon_style_active: $group_icon_style_active
   icon_style_inactive: $group_icon_style_inactive
+  widget_style_active: $group_widget_style_active
+  widget_style_inactive: $group_widget_style_inactive

--- a/appdaemon/widgets/heater.yaml
+++ b/appdaemon/widgets/heater.yaml
@@ -31,3 +31,5 @@ static_css:
 css:
   icon_style_active: $heater_icon_style_active
   icon_style_inactive: $heater_icon_style_inactive
+  widget_style_active: $heater_widget_style_active
+  widget_style_inactive: $heater_widget_style_inactive

--- a/appdaemon/widgets/input_boolean.yaml
+++ b/appdaemon/widgets/input_boolean.yaml
@@ -19,11 +19,13 @@ icons:
   icon_on: $input_boolean_icon_on
   icon_off: $input_boolean_icon_off
 static_icons: []
-css:
-  icon_style_active: $input_boolean_icon_style_active 
-  icon_style_inactive: $input_boolean_icon_style_inactive 
 static_css:
   title_style: $input_boolean_title_style
   title2_style: $input_boolean_title2_style
   state_text_style: $input_boolean_state_text_style
   widget_style: $input_boolean_widget_style
+css:
+  icon_style_active: $input_boolean_icon_style_active 
+  icon_style_inactive: $input_boolean_icon_style_inactive 
+  widget_style_active: $input_boolean_widget_style_active
+  widget_style_inactive: $input_boolean_widget_style_inactive

--- a/appdaemon/widgets/javascript/javascript.js
+++ b/appdaemon/widgets/javascript/javascript.js
@@ -101,6 +101,7 @@ function javascript(widget_id, url, skin, parameters)
     
     self.set_icon(self, "icon", self.icons.icon_inactive)
     self.set_field(self, "icon_style", self.css.icon_inactive_style)
+    self.set_field(self, "widget_style", self.css.widget_style_inactive)
     
     self.command = command
     
@@ -108,6 +109,7 @@ function javascript(widget_id, url, skin, parameters)
     {
         self.set_icon(self, "icon", self.icons.icon_active)
         self.set_field(self, "icon_style", self.css.icon_active_style)
+        self.set_field(self, "widget_style", self.css.widget_style_active)
         eval(self.command);
     }
 }

--- a/appdaemon/widgets/light.yaml
+++ b/appdaemon/widgets/light.yaml
@@ -32,3 +32,5 @@ static_css:
 css:
   icon_style_active: $light_icon_style_active
   icon_style_inactive: $light_icon_style_inactive
+  widget_style_active: $light_widget_style_active
+  widget_style_inactive: $light_widget_style_inactive

--- a/appdaemon/widgets/light_with_brightness.yaml
+++ b/appdaemon/widgets/light_with_brightness.yaml
@@ -27,3 +27,5 @@ static_css:
 css:
   icon_style_active: $light_with_brightness_icon_style_active
   icon_style_inactive: $light_with_brightness_icon_style_inactive
+  widget_style_active: $light_with_brightness_widget_style_active
+  widget_style_inactive: $light_with_brightness_widget_style_inactive

--- a/appdaemon/widgets/light_with_colorpicker.yaml
+++ b/appdaemon/widgets/light_with_colorpicker.yaml
@@ -24,3 +24,5 @@ static_css:
 css:
   icon_style_active: $light_with_colorpicker_icon_style_active
   icon_style_inactive: $light_with_colorpicker_icon_style_inactive
+  widget_style_active: $light_with_colorpicker_widget_style_active
+  widget_style_inactive: $light_with_colorpicker_widget_style_inactive

--- a/appdaemon/widgets/lock.yaml
+++ b/appdaemon/widgets/lock.yaml
@@ -19,11 +19,13 @@ icons:
   icon_on: $lock_icon_on
   icon_off: $lock_icon_off
 static_icons: []
-css:
-  icon_style_active: $lock_icon_style_active 
-  icon_style_inactive: $lock_icon_style_inactive 
 static_css:
   title_style: $lock_title_style
   title2_style: $lock_title2_style
   state_text_style: $lock_state_text_style
   widget_style: $lock_widget_style
+css:
+  icon_style_active: $lock_icon_style_active 
+  icon_style_inactive: $lock_icon_style_inactive 
+  widget_style_active: $lock_widget_style_active
+  widget_style_inactive: $lock_widget_style_inactive

--- a/appdaemon/widgets/media_player.yaml
+++ b/appdaemon/widgets/media_player.yaml
@@ -53,3 +53,5 @@ static_css:
 css:
   icon_style_active: $media_player_icon_style_active
   icon_style_inactive: $media_player_icon_style_inactive
+  widget_style_active: $media_player_widget_style_active
+  widget_style_inactive: $media_player_widget_style_inactive

--- a/appdaemon/widgets/mode.yaml
+++ b/appdaemon/widgets/mode.yaml
@@ -15,11 +15,13 @@ icons:
   icon_on: $mode_icon_on
   icon_off: $mode_icon_off
 static_icons: []
-css:
-  icon_style_active: $mode_icon_style_active 
-  icon_style_inactive: $mode_icon_style_inactive 
 static_css:
   title_style: $mode_title_style
   title2_style: $mode_title2_style
   state_text_style: $mode_state_text_style
   widget_style: $mode_widget_style
+css:
+  icon_style_active: $mode_icon_style_active 
+  icon_style_inactive: $mode_icon_style_inactive 
+  widget_style_active: $mode_widget_style_active
+  widget_style_inactive: $mode_widget_style_inactive

--- a/appdaemon/widgets/navigate.yaml
+++ b/appdaemon/widgets/navigate.yaml
@@ -14,4 +14,6 @@ static_css:
 css:
   icon_active_style: $navigate_icon_active_style
   icon_inactive_style: $navigate_icon_inactive_style
+  widget_style_active: $navigate_widget_style_active
+  widget_style_inactive: $navigate_widget_style_inactive
 static_icons: []

--- a/appdaemon/widgets/reload.yaml
+++ b/appdaemon/widgets/reload.yaml
@@ -15,4 +15,6 @@ static_css:
 css:
   icon_active_style: $reload_icon_active_style
   icon_inactive_style: $reload_icon_inactive_style
+  widget_style_active: $reload_widget_style_active
+  widget_style_inactive: $reload_widget_style_inactive
 static_icons: []

--- a/appdaemon/widgets/scene.yaml
+++ b/appdaemon/widgets/scene.yaml
@@ -21,11 +21,13 @@ icons:
   icon_on: $scene_icon_on
   icon_off: $scene_icon_off
 static_icons: []
-css:
-  icon_style_active: $scene_icon_style_active 
-  icon_style_inactive: $scene_icon_style_inactive 
 static_css:
   title_style: $scene_title_style
   title2_style: $scene_title2_style
   state_text_style: $scene_state_text_style
   widget_style: $scene_widget_style
+css:
+  icon_style_active: $scene_icon_style_active 
+  icon_style_inactive: $scene_icon_style_inactive 
+  widget_style_active: $scene_widget_style_active
+  widget_style_inactive: $scene_widget_style_inactive

--- a/appdaemon/widgets/script.yaml
+++ b/appdaemon/widgets/script.yaml
@@ -21,11 +21,13 @@ icons:
   icon_on: $script_icon_on
   icon_off: $script_icon_off
 static_icons: []
-css:
-  icon_style_active: $script_icon_style_active 
-  icon_style_inactive: $script_icon_style_inactive 
 static_css:
   title_style: $script_title_style
   title2_style: $script_title2_style
   state_text_style: $script_state_text_style
   widget_style: $script_widget_style
+css:
+  icon_style_active: $script_icon_style_active 
+  icon_style_inactive: $script_icon_style_inactive 
+  widget_style_active: $script_widget_style_active
+  widget_style_inactive: $script_widget_style_inactive

--- a/appdaemon/widgets/switch.yaml
+++ b/appdaemon/widgets/switch.yaml
@@ -19,11 +19,13 @@ icons:
   icon_on: $switch_icon_on
   icon_off: $switch_icon_off
 static_icons: []
-css:
-  icon_style_active: $switch_icon_style_active 
-  icon_style_inactive: $switch_icon_style_inactive 
 static_css:
   title_style: $switch_title_style
   title2_style: $switch_title2_style
   state_text_style: $switch_state_text_style
   widget_style: $switch_widget_style
+css:
+  icon_style_active: $switch_icon_style_active 
+  icon_style_inactive: $switch_icon_style_inactive 
+  widget_style_active: $switch_widget_style_active
+  widget_style_inactive: $switch_widget_style_inactive

--- a/docs/DASHBOARD_CREATION.rst
+++ b/docs/DASHBOARD_CREATION.rst
@@ -863,6 +863,8 @@ Style Arguments:
 -  ``title_style``
 -  ``title2_style``
 -  ``state_text_style``
+-  ``widget_style_active``
+-  ``widget_style_inactive``
 
 label
 ~~~~~
@@ -917,6 +919,8 @@ Style Arguments:
 -  ``icon_style_inactive``
 -  ``title_style``
 -  ``title2_style``
+-  ``widget_style_active``
+-  ``widget_style_inactive``
 
 script
 ~~~~~~
@@ -946,6 +950,8 @@ Style Arguments:
 -  ``icon_style_inactive``
 -  ``title_style``
 -  ``title2_style``
+-  ``widget_style_active``
+-  ``widget_style_inactive``
 
 mode
 ~~~~
@@ -979,6 +985,8 @@ Style Arguments:
 -  ``icon_style_inactive``
 -  ``title_style``
 -  ``title2_style``
+-  ``widget_style_active``
+-  ``widget_style_inactive``
 
 switch
 ~~~~~~
@@ -1008,6 +1016,8 @@ Cosmetic Arguments
 -  ``icon_style_inactive``
 -  ``title_style``
 -  ``title2_style``
+-  ``widget_style_active``
+-  ``widget_style_inactive``
 
 lock
 ~~~~
@@ -1045,6 +1055,8 @@ Cosmetic Arguments
 -  ``icon_style_inactive``
 -  ``title_style``
 -  ``title2_style``
+-  ``widget_style_active``
+-  ``widget_style_inactive``
 
 cover
 ~~~~~
@@ -1075,6 +1087,8 @@ Cosmetic Arguments
 -  ``icon_style_inactive``
 -  ``title_style``
 -  ``title2_style``
+-  ``widget_style_active``
+-  ``widget_style_inactive``
 
 input\_boolean
 ~~~~~~~~~~~~~~
@@ -1104,6 +1118,8 @@ Cosmetic Arguments
 -  ``icon_style_inactive``
 -  ``title_style``
 -  ``title2_style``
+-  ``widget_style_active``
+-  ``widget_style_inactive``
 
 binary\_sensor
 ~~~~~~~~~~~~~~
@@ -1133,6 +1149,8 @@ Cosmetic Arguments
 -  ``icon_style_inactive``
 -  ``title_style``
 -  ``title2_style``
+-  ``widget_style_active``
+-  ``widget_style_inactive``
 
 light
 ~~~~~
@@ -1209,6 +1227,8 @@ Cosmetic Arguments
 -  ``level_style``
 -  ``level_up_style``
 -  ``level_down_style``
+-  ``widget_style_active``
+-  ``widget_style_inactive``
 
 input\_slider
 ~~~~~~~~~~~~~
@@ -1312,6 +1332,8 @@ Cosmetic Arguments
 -  ``level_style``
 -  ``level_up_style``
 -  ``level_down_style``
+-  ``widget_style_active``
+-  ``widget_style_inactive``
 
 group
 ~~~~~
@@ -1353,6 +1375,8 @@ Cosmetic Arguments
 -  ``level_style``
 -  ``level_up_style``
 -  ``level_down_style``
+-  ``widget_style_active``
+-  ``widget_style_inactive``
 
 navigate
 ~~~~~~~~
@@ -1666,6 +1690,8 @@ All entries are required but can be left blank by using double quotes.
     light_level_up_style: "color: $gray_light"
     light_level_down_style: "color: $gray_light"
     light_widget_style: ""
+    light_widget_style_active: ""
+    light_widget_style_inactive: ""
 
 Images can be included - create a sub directory in your skin directory,
 call it ``img`` or whatever you like, then refer to it in the css as:


### PR DESCRIPTION
I had a desire for the entire widget to change to reflect whether the entity was active or inactive. I use this in my dashboards in conjunction with "display: none" on the icons so I rely on the design of the widget alone to represent the state.

I have updated all widgets that previously allowed 'icon_style_active' and 'icon_style_inactive' and updated all skins