### PR TITLE
Typo?

### DIFF
--- a/docs/INSTALL.rst
+++ b/docs/INSTALL.rst
@@ -124,7 +124,7 @@ An example secrets.yaml might look like this:
 
 .. code:: yaml
 
-    home_assistant_key_key: password123
+    home_assistant_key: password123
     appdaemon_key: password456
 
 The secrets can then be referred to as follows:


### PR DESCRIPTION
The secrets section seemed to have an error in it.  Also, a question about the previous statement under "secrets."  My installation fails to find the secrets.yaml file in my root HA folder, but others have reported that adding an additional secrets.yaml file to the /appdaemon/ folder works.