### PR TITLE
change homeassistant.appapi to appdaemon.appapi

### DIFF
--- a/docs/TUTORIAL.rst
+++ b/docs/TUTORIAL.rst
@@ -131,7 +131,7 @@ different scenes in a different version of the App.
 
 .. code:: python
 
-    import homeassistant.appapi as appapi
+    import appdaemon.appapi as appapi
 
     class OutsideLights(appapi.AppDaemon):
 
@@ -169,7 +169,7 @@ terms:
 
 .. code:: python
 
-    import homeassistant.appapi as appapi
+    import appdaemon.appapi as appapi
 
     class FlashyMotionLights(appapi.AppDaemon):
 
@@ -200,7 +200,7 @@ activated and bales out after 10 iterations.
 
 .. code:: python
 
-    import homeassistant.appapi as appapi
+    import appdaemon.appapi as appapi
 
     class MotionLights(appapi.AppDaemon):
 


### PR DESCRIPTION
As far as I understand it (I'm a noob), there is no such thing as homeassistant.appapi , but rather should be appdaemon.appapi. I encountered this issue as described in this thread: https://community.home-assistant.io/t/appdaemon-first-steps/24820/6?u=dolores