### PR TITLE
Fix cert_path config key in hassapi call_service

### DIFF
--- a/appdaemon/plugins/hass/hassapi.py
+++ b/appdaemon/plugins/hass/hassapi.py
@@ -413,8 +413,8 @@ class Hass(appapi.AppDaemon):
         )
 
         config = self.AD.get_plugin(self._get_namespace(**kwargs)).config
-        if "certpath" in config:
-            certpath = config["certpath"]
+        if "cert_path" in config:
+            certpath = config["cert_path"]
         else:
             certpath = None
 


### PR DESCRIPTION
I was having trouble getting Appdaemon and my self signed hass cert to work.
It could connect and read states from hass but any service call threw invalid SSL cert errors.
A bit of digging turned up that the call_service function was missing the underscore in cert_path.

Can also be worked around by adding a certpath key to the appdaemon.yaml with the same value as cert_path. 