### PR TITLE
EXTRA_CMD did not work with whitespaces

### DIFF
--- a/dockerStart.sh
+++ b/dockerStart.sh
@@ -43,4 +43,5 @@ if [ -n "$DASH_URL" ]; then
 fi
 
 # Lets run it!
-appdaemon -c $CONF $EXTRA_CMD
+appdaemon -c $CONF "$EXTRA_CMD"
+


### PR DESCRIPTION
e.g. between date and time when using time travel:

`-e EXTRA_CMD="-s2018-02-04 05:29:00"`