### PR TITLE
Upgraded the baseweather widget

### DIFF
--- a/appdaemon/assets/css/obsidian/variables.yaml
+++ b/appdaemon/assets/css/obsidian/variables.yaml
@@ -174,7 +174,7 @@ clock_widget_style: "border-style: solid; border-width: 2px; border-color: white
 
 weather_main_style: "color: $cyan; font-size: 75%"
 weather_unit_style: "color: $cyan; font-size: 200%"
-weather_sub_style: "color: $white; font-size: 130%"
+weather_sub_style: "color: $white; font-size: 100%"
 weather_widget_style: $stripped
 
 weather_summary_title_style: $style_title

--- a/appdaemon/widgets/baseweather/baseweather.css
+++ b/appdaemon/widgets/baseweather/baseweather.css
@@ -1,73 +1,104 @@
 .widget-baseweather-{{id}} {
-	color: white;
+    color: white;
 }
 
 .widget-baseweather-{{id}} h1 {
-	margin-bottom: 0px;
+    margin-bottom: 0px;
 }
 
 .widget-baseweather-{{id}} [class^="primary"] {
-	display: inline-block;
-	vertical-align: middle;
-	padding: 0;
-	margin-left: 10px;
-	margin-right: 10px;
-	margin-top: 0px;
-	margin-bottom: 0px;
-}
-
-.widget-baseweather-{{id}} [class^="secondary"] {
-	display: inline-block;
-	vertical-align: middle;
-	padding: 0;
-	margin-left: 0px;
-	margin-right: 0px;
-	margin-top: 0px;
-	margin-bottom: 0px;
+    display: inline-block;
+    vertical-align: middle;
+    padding: 0;
+    margin-left: 10px;
+    margin-right: 10px;
+    margin-top: 0px;
+    margin-bottom: 0px;
 }
 
 .widget-baseweather-{{id}} .primary-climacon {
-	font-family: "Climacons-Font";
-	font-size: 70px;
+    font-family: "Climacons-Font";
+    font-size: 70px;
 }
 
 .widget-baseweather-{{id}} .primary-info {
-	font-size: 300%;
-	font-weight: 400;
+    font-size: 300%;
+    font-weight: 400;
 }
 
 .widget-baseweather-{{id}} .primary-unit {
-	font-size: 100%;
-	font-weight: 400;
-	margin-left: 0;
-	margin-top: 20px;
-	vertical-align: top;
+    font-size: 100%;
+    font-weight: 400;
+    margin-left: 0;
+    margin-top: 20px;
+    vertical-align: top;
 }
 
-.widget-baseweather-{{id}} .secondary-icon {
-	font-family: "Climacons-Font";
-	font-size: 40px;
-	margin-left: 10px;
-	margin-right: 0px;
+.widget-baseweather-{{id}} [class^="secondary-"] {
+    padding: 0;
+    margin: 0px;
+}
+
+.widget-baseweather-{{id}} .secondary-detail {
+    display: inline-block;
+    font-size: 125%;
+    font-weight: 200;
+    vertical-align: middle;
+    padding: 2px 4px;
 }
 
 .widget-baseweather-{{id}} .secondary-climacon {
-	font-family: "Climacons-Font";
-	font-size: 55px;
-	margin-left: 10px;
-	margin-right: 10px;
+    font-family: "Climacons-Font";
+    font-size: 40px;
+    margin-left: 10px;
+    margin-right: 0px;
 }
 
-.widget-baseweather-{{id}} .secondary-info {
-	font-size: 125%;
-	font-weight: 200;
+.widget-baseweather-{{id}} .rain:before{
+    content: "\e009";
+}
+
+.widget-baseweather-{{id}} .snow:before{
+    content: "\e036";
+}
+
+.widget-baseweather-{{id}} .sleet:before{
+    content: "\e003";
+}
+
+.widget-baseweather-{{id}} .wind:before{
+    content: "\e021";
+}
+
+.widget-baseweather-{{id}} .fog:before{
+    content: "\e01b";
+}
+
+.widget-baseweather-{{id}} .cloudy:before{
+    content: "\e000";
+}
+
+.widget-baseweather-{{id}} .clear-day:before{
+    content: "\e028";
+}
+
+.widget-baseweather-{{id}} .clear-night:before{
+    content: "\e02d";
+}
+
+.widget-baseweather-{{id}} .partly-cloudy-day:before{
+    content: "\e001";
+}
+
+.widget-baseweather-{{id}} .partly-cloudy-night:before{
+    content: "\e002";
 }
 
 .widget-baseweather-{{id}} hr {
-	width: 90%;
-	border: 0;
-	height: 1px;
-	background: rgba(255, 255, 255, 0.25);
-	margin-top: 15px;
-	margin-bottom: 15px;
+    width: 90%;
+    border: 0;
+    height: 1px;
+    background: rgba(255, 255, 255, 0.25);
+    margin-top: 15px;
+    margin-bottom: 15px;
 }

--- a/appdaemon/widgets/baseweather/baseweather.html
+++ b/appdaemon/widgets/baseweather/baseweather.html
@@ -1,33 +1,74 @@
 <h1 class="title" data-bind="text: title, attr:{ style: title_style}"></h1>
 <div data-bind="attr: {style: main_style}">
-	<p class="primary-climacon" data-bind="html: dark_sky_icon"></p>
-	<p class="primary-info" data-bind="text: dark_sky_temperature"></p>
-	<p class="primary-unit" data-bind="html: unit, attr: {style: unit_style}"></p>
+<p class="primary-climacon" data-bind="css: icon"></p>
+<p class="primary-info" data-bind="text: temperature"></p>
+<p class="primary-unit" data-bind="html: unit, attr: {style: unit_style}"></p>
 <br>
+</div>
 <div data-bind="attr: {style: sub_style}">
-	<p class="secondary-info">Humidity:&nbsp;</p>
-	<p class="secondary-info" data-bind="text: dark_sky_humidity"></p>
-	<p class="secondary-info">%</p>
-	<br>
-	<p class="secondary-info">Apparent Temp:&nbsp;</p>
-	<p class="secondary-info" data-bind="html: dark_sky_apparent_temperature"></p>
-	<p class="secondary-info" data-bind="html: unit"></p>
-	<br>
-	<p class="secondary-info">Rain:&nbsp;</p>
-	<p class="secondary-info" data-bind="text: dark_sky_precip_probability"></p>
-	<p class="secondary-info">&nbsp;%</p>
-	<p class="secondary-info">&nbsp;/&nbsp;</p>
-	<p class="secondary-info" data-bind="text: dark_sky_precip_intensity"></p>
-	<p class="secondary-info">in</p>
-	<br>
-	<p class="secondary-info">Wind:&nbsp;</p>
-	<p class="secondary-info" data-bind="text: dark_sky_wind_speed"></p>
-	<p class="secondary-info">&nbsp;Mph</p>
-	<p class="secondary-info">&nbsp;/&nbsp;</p>
-	<p class="secondary-info" data-bind="html: dark_sky_wind_bearing"></p>
-	<p class="secondary-info">&nbsp;&deg;</p>
-	<br>
-	<p class="secondary-info">Pressure:&nbsp;</p>
-	<p class="secondary-info" data-bind="text: dark_sky_pressure"></p>
-	<p class="secondary-info">&nbsp;Mbar</p>
+<p class="secondary-detail" data-bind="visible: apparent_temperature">
+<span class="secondary-icon mdi mdi-thermometer-lines" title="Apparent Temp" data-bind="visible: prefer_icons"></span>
+<span class="secondary-info" data-bind="visible: !prefer_icons()">Apparent Temp:&nbsp;</span>
+<span class="secondary-info" data-bind="html: apparent_temperature"></span>
+<span class="secondary-info" data-bind="html: unit, attr: {style: sub_unit_style}"></span>
+</p>
+<p class="secondary-detail" data-bind="visible: humidity">
+<span class="secondary-icon mdi mdi-water-percent" title="Humidity" data-bind="visible: prefer_icons"></span>
+<span class="secondary-info" data-bind="visible: !prefer_icons()">Humidity:&nbsp;</span>
+<span class="secondary-info" data-bind="text: humidity"></span>
+<span class="secondary-unit" data-bind="attr: {style: sub_unit_style}">%</span>
+<br>
+</p>
+<p class="secondary-detail"  data-bind="visible: precip_probability() || precip_intensity()">
+<span data-bind="visible: precip_probability">
+<span class="secondary-icon mdi" title="Rain" data-bind="visible: prefer_icons, css: precip_type_icon"></span>
+<span class="secondary-info" data-bind="visible: !prefer_icons()">Rain:&nbsp;</span>
+<span class="secondary-info" data-bind="text: precip_probability"></span>
+<span class="secondary-unit" data-bind="attr: {style: sub_unit_style}">%</span>
+</span>
+<span data-bind="visible: precip_intensity">
+<span class="secondary-info" data-bind="visible: precip_intensity() && precip_probability()">
+&nbsp;/&nbsp;
+</span>
+<span class="secondary-info" data-bind="text: precip_intensity"></span>
+<span class="secondary-unit" data-bind="text: rain_unit, attr: {style: sub_unit_style}"></span>
+</span>
+</p>
+<p class="secondary-detail" data-bind="visible: wind_speed">
+<span class="secondary-icon mdi mdi-weather-windy" data-bind="visible: prefer_icons, css: bearing_icon, attr: {title: wind_bearing() + '&deg;'}"></span>
+<span class="secondary-info" data-bind="visible: !prefer_icons()">Wind:&nbsp;</span>
+<span class="secondary-info" data-bind="text: wind_speed"></span>
+<span class="secondary-unit" data-bind="text: wind_unit, attr: {style: sub_unit_style}"></span>
+</p>
+<p class="secondary-detail" data-bind="visible: wind_bearing() && !prefer_icons()">
+<span class="secondary-info" data-bind="html: wind_bearing"></span>
+<span class="secondary-unit" data-bind="attr: {style: sub_unit_style}">&deg;</span>
+</p>
+<p class="secondary-detail" data-bind="visible: pressure() != ''">
+<span class="secondary-icon mdi mdi-gauge" data-bind="visible: prefer_icons"></span>
+<span class="secondary-info" data-bind="visible: !prefer_icons()">Pressure:&nbsp;</span>
+<span class="secondary-info" data-bind="text: pressure"></span>
+<span class="secondary-info" data-bind="text: pressure_unit, attr: {style: sub_unit_style}"></span>
+</p>
+<div data-bind="visible: show_forecast"> 
+<hr>
+<h1 class="title" data-bind="text: forecast_title, attr:{ style: title_style}, visible: show_forecast"></h1>
+<p class="secondary-detail" data-bind="visible: forecast_temperature">
+<span class="secondary-climacon" data-bind="css: icon"></span>
+</p>
+<p class="secondary-detail" data-bind="visible: forecast_temperature">
+<span class="secondary-info" data-bind="text: forecast_temperature"></span>
+<span class="secondary-info" data-bind="visible: forecast_apparent_temperature">
+<span>/</span>
+<span class="secondary-info" data-bind="text: forecast_apparent_temperature"></span>
+</span>
+</p>
+<p class="secondary-detail" data-bind="visible: forecast_precip_probability">
+<span class="secondary-icon mdi" title="Rain" data-bind="visible: prefer_icons, css: forecast_precip_type_icon"></span>
+<span class="secondary-info" data-bind="visible: !prefer_icons()">Rain:&nbsp;</span>
+<span class="secondary-info" data-bind="text: forecast_precip_probability">
+</span>
+<span class="secondary-icon" data-bind="attr: {style: sub_unit_style}">%</span>
+</p>
+</div>
 </div>

--- a/appdaemon/widgets/baseweather/baseweather.js
+++ b/appdaemon/widgets/baseweather/baseweather.js
@@ -5,25 +5,9 @@ function baseweather(widget_id, url, skin, parameters)
 
     self = this;
 
-    self.weather_icons =
-    {
-      "rain": '&#xe009',
-      "snow": '&#xe036',
-      "sleet": '&#xe003',
-      "wind": '&#xe021',
-      "fog": '&#xe01b',
-      "cloudy": '&#xe000',
-      "clear-day": '&#xe028',
-      "clear-night": '&#xe02d',
-      "partly-cloudy-day": '&#xe001',
-      "partly-cloudy-night": '&#xe002'    
-    };
-
     // Initialization
 
     self.widget_id = widget_id;
-
-    // Store on brightness or fallback to a default
 
     // Parameters may come in useful later on
 
@@ -38,26 +22,47 @@ function baseweather(widget_id, url, skin, parameters)
     self.OnStateAvailable = OnStateAvailable;
     self.OnStateUpdate = OnStateUpdate;
 
-    var monitored_entities =
-    [
-        {"entity": "sensor.dark_sky_temperature", "initial": self.OnStateAvailable, "update": self.OnStateUpdate},
-        {"entity": "sensor.dark_sky_humidity", "initial": self.OnStateAvailable, "update": self.OnStateUpdate},
-        {"entity": "sensor.dark_sky_precip_probability", "initial": self.OnStateAvailable, "update": self.OnStateUpdate},
-        {"entity": "sensor.dark_sky_precip_intensity", "initial": self.OnStateAvailable, "update": self.OnStateUpdate},
-        {"entity": "sensor.dark_sky_wind_speed", "initial": self.OnStateAvailable, "update": self.OnStateUpdate},
-        {"entity": "sensor.dark_sky_pressure", "initial": self.OnStateAvailable, "update": self.OnStateUpdate},
-        {"entity": "sensor.dark_sky_wind_bearing", "initial": self.OnStateAvailable, "update": self.OnStateUpdate},
-        {"entity": "sensor.dark_sky_apparent_temperature", "initial": self.OnStateAvailable, "update": self.OnStateUpdate},
-        {"entity": "sensor.dark_sky_icon", "initial": self.OnStateAvailable, "update": self.OnStateUpdate}
-    ];
+    // Map will be used to know what field are we going to update from what sensor
+    self.entities_map = {}
 
+    var monitored_entities = []
+
+    var entities = $.extend({}, parameters.entities, parameters.sensors);
+    for (var key in entities)
+    {
+        var entity = entities[key]
+        if (entity != '' && check_if_forecast_sensor(parameters.show_forecast, entity))
+        {
+            monitored_entities.push({
+                "entity": entity, "initial": self.OnStateAvailable, "update": self.OnStateUpdate
+            })
+            self.entities_map[entity] = key
+        }
+    }
+
+    // If forecast is disabled - dont monitor the forecast sensors
+    function check_if_forecast_sensor(show_forecast, entity)
+    {
+        if (show_forecast)
+        {
+          return true
+        }
+        else if(entity.substring(0, 9) === "forecast_")
+        {
+          return false
+        }
+        else
+        {
+          return true
+        }
+    }
     // Finally, call the parent constructor to get things moving
 
     WidgetBase.call(self, widget_id, url, skin, parameters, monitored_entities, callbacks);
 
     // Function Definitions
 
-    // The StateAvailable function will be called when
+    // The OnStateAvailable function will be called when
     // self.state[<entity>] has valid information for the requested entity
     // state is the initial state
     // Methods
@@ -69,22 +74,48 @@ function baseweather(widget_id, url, skin, parameters)
 
     function OnStateAvailable(self, state)
     {
-        if (state.entity_id == "sensor.dark_sky_temperature")
+        field = self.entities_map[state.entity_id] 
+        if (field == 'temperature')
         {
             self.set_field(self, "unit", state.attributes.unit_of_measurement)
         }
+        else if (field == 'wind_speed')
+        {
+            self.set_field(self, "wind_unit", state.attributes.unit_of_measurement)
+        }
+        else if (field == 'pressure')
+        {
+            self.set_field(self, "pressure_unit", state.attributes.unit_of_measurement)
+        } 
+        else if (field == 'precip_intensity')
+        {
+            self.set_field(self, "rain_unit", state.attributes.unit_of_measurement)
+        } 
         set_view(self, state)
     }
 
     function set_view(self, state)
     {
-        if (state.entity_id == "sensor.dark_sky_icon")
+        field = self.entities_map[state.entity_id] 
+        if (field)
         {
-            self.set_field(self, "dark_sky_icon", self.weather_icons[state.state])
-        }
-        else
-        {
-            var field = state.entity_id.split(".")[1];
+            if (field == 'precip_type')
+            {
+                self.set_field(self, "precip_type_icon", self.parameters.icons[state.state])
+            }
+            else if (field == 'forecast_precip_type')
+            {
+                self.set_field(self, "forecast_precip_type_icon", self.parameters.icons[state.state])
+            }
+            else if (field == 'wind_bearing')
+            {
+                var counts = [45, 90, 135, 180, 225, 270, 315]
+                var goal = (parseInt(state.state) + 270) % 360
+                var closest = counts.reduce(function(prev, curr) {
+                      return (Math.abs(curr - goal) < Math.abs(prev - goal) ? curr : prev);
+                });
+                self.set_field(self, "bearing_icon", "mdi-rotate-" + closest)
+            }
             self.set_field(self, field, state.state)
         }
     }

--- a/appdaemon/widgets/weather.yaml
+++ b/appdaemon/widgets/weather.yaml
@@ -1,22 +1,58 @@
 widget_type: baseweather
 fields:
   title: ""
+  show_forecast: 0
+  prefer_icons: 0
   unit: ""
-  dark_sky_temperature: ""
-  dark_sky_humidity: ""
-  dark_sky_precip_probability: ""
-  dark_sky_precip_intensity: ""
-  dark_sky_wind_speed: ""
-  dark_sky_pressure: ""
-  dark_sky_wind_bearing: ""
-  dark_sky_apparent_temperature: ""
-  dark_sky_icon: ""
+  wind_unit: ""
+  pressure_unit: ""
+  rain_unit: ""
+  temperature: ""
+  humidity: ""
+  precip_probability: ""
+  precip_intensity: ""
+  precip_type: ""
+  wind_speed: ""
+  pressure: ""
+  wind_bearing: ""
+  apparent_temperature: ""
+  icon: ""
+  bearing_icon: "mdi-rotate-0"
+  precip_type_icon: "mdi-umbrella"
+  forecast_title: ""
+  forecast_temperature: ""
+  forecast_apparent_temperature: ""
+  forecast_icon: ""
+  forecast_precip_probability: ""
+  forecast_precip_type: ""
+  forecast_precip_type_icon: "mdi-umbrella"
+entities:
+  icon: sensor.dark_sky_icon
+  temperature: sensor.dark_sky_temperature
+  apparent_temperature: sensor.dark_sky_apparent_temperature
+  humidity: sensor.dark_sky_humidity
+  precip_probability: sensor.dark_sky_precip_probability
+  precip_intensity: sensor.dark_sky_precip_intensity
+  precip_type: sensor.dark_sky_precip
+  pressure: sensor.dark_sky_pressure
+  wind_speed: sensor.dark_sky_wind_speed
+  wind_bearing: sensor.dark_sky_wind_bearing
+  forecast_icon: sensor.dark_sky_icon_1
+  forecast_temperature: sensor.dark_sky_temperature_1
+  forecast_apparent_temperature: sensor.dark_sky_apparent_temperature_1
+  forecast_precip_probability: sensor.dark_sky_precip_probability_1
+  forecast_precip_type: sensor.dark_sky_precip_1
 css: []
 static_css:
   title_style: $weather_sub_style
   unit_style: $weather_unit_style
   main_style: $weather_main_style
   sub_style: $weather_sub_style
+  sub_unit_style: $weather_sub_style
   widget_style: $weather_widget_style
-icons: []
+icons:
+  snow: mdi-snowflake
+  rain: mdi-umbrella
+  sleet: mdi-weather-snowy-rainy
+  unknown: mdi-umbrella
 static_icons: []

--- a/docs/DASHBOARD_CREATION.rst
+++ b/docs/DASHBOARD_CREATION.rst
@@ -711,18 +711,29 @@ Style Arguments:
 weather
 ~~~~~~~
 
-Up to date weather reports. Requires dark sky to be configured in Home
-Assistant with at minimum the following sensors:
+Up to date weather reports. By default it's configured to work with dark sky
+sensor. To use all the features you need to add these sensors to
+monitored_conditions:
 
 -  temperature
+-  apparent\_temperature
 -  humidity
 -  precip\_probability
 -  precip\_intensity
+-  precip\_type
 -  wind\_speed
--  pressure
 -  wind\_bearing
--  apparent\_temperature
+-  pressure
 -  icon
+
+To have the forecast displayed set ``show_forecast`` to 1. For it to work you
+additionally need to add the forecast option in dark_sky Home Assistant
+configuration.
+
+.. code:: yaml
+
+    forecast:
+      - 1
 
 Mandatory arguments:
 ^^^^^^^^^^^^^^^^^^^^
@@ -732,7 +743,40 @@ None
 Optional Arguments:
 ^^^^^^^^^^^^^^^^^^^
 
-None
+- ``title``
+- ``show_forecast`` - show the forecast
+- ``prefer_icons`` - use icons instead of text
+- ``forecast_title`` - title of the forecast if enabled
+- ``sensors`` - list of sensors used by the widget
+
+You can change the entities used by the widget by overwriting thier values 
+in ``sensors`` key in configuration.
+
+Example with default values:
+
+.. code:: yaml
+
+    sample_weather:
+      title: Today
+      show_foreacast: 1
+      prefer_icons: 1
+      forecast_title: Tomorrow
+      sensors:
+        icon: sensor.dark_sky_icon
+        temperature: sensor.dark_sky_temperature
+        apparent_temperature: sensor.dark_sky_apparent_temperature
+        humidity: sensor.dark_sky_humidity
+        precip_probability: sensor.dark_sky_precip_probability
+        precip_intensity: sensor.dark_sky_precip_intensity
+        precip_type: sensor.dark_sky_precip
+        pressure: sensor.dark_sky_pressure
+        wind_speed: sensor.dark_sky_wind_speed
+        wind_bearing: sensor.dark_sky_wind_bearing
+        forecast_icon: sensor.dark_sky_icon_1
+        forecast_temperature: sensor.dark_sky_temperature_1
+        forecast_apparent_temperature: sensor.dark_sky_apparent_temperature_1
+        forecast_precip_probability: sensor.dark_sky_precip_probability_1
+        forecast_precip_type: sensor.dark_sky_precip_1
 
 Cosmetic Arguments:
 ^^^^^^^^^^^^^^^^^^^
@@ -741,6 +785,8 @@ Cosmetic Arguments:
 -  ``main_style``
 -  ``unit_style``
 -  ``sub_style``
+-  ``sub_unit_style``
+-  ``title_style``
 
 weather_summary
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
* added the ability to change the sensors used
* added dynamic units for more sensors
* added option for showing forecast (show_forecast: 1)
* added icons for conditions (prefer_icons: 1)
* added the option to show Rain/Snow depending on precip_type sensor (and change icons)
* wind icon rotates acording to wind bearing

There are some css changes (used 4 spaces instead of tabs). 
Had to remove the indentions from the html file to get rid of those ugly spaces between display-block elements.