### PR TITLE
baseweather  - Fix for dark_sky forecast temperature

### DIFF
--- a/appdaemon/widgets/baseweather/baseweather.html
+++ b/appdaemon/widgets/baseweather/baseweather.html
@@ -53,14 +53,14 @@
 <div data-bind="visible: show_forecast"> 
 <hr>
 <h1 class="title" data-bind="text: forecast_title, attr:{ style: title_style}, visible: show_forecast"></h1>
-<p class="secondary-detail" data-bind="visible: forecast_temperature">
-<span class="secondary-climacon" data-bind="css: icon"></span>
+<p class="secondary-detail" data-bind="visible: forecast_temperature_min">
+<span class="secondary-climacon" data-bind="css: forecast_icon"></span>
 </p>
-<p class="secondary-detail" data-bind="visible: forecast_temperature">
-<span class="secondary-info" data-bind="text: forecast_temperature"></span>
-<span class="secondary-info" data-bind="visible: forecast_apparent_temperature">
+<p class="secondary-detail" data-bind="visible: forecast_temperature_min">
+<span class="secondary-info" data-bind="text: forecast_temperature_min"></span>
+<span class="secondary-info" data-bind="visible: forecast_temperature_max">
 <span>/</span>
-<span class="secondary-info" data-bind="text: forecast_apparent_temperature"></span>
+<span class="secondary-info" data-bind="text: forecast_temperature_max"></span>
 </span>
 </p>
 <p class="secondary-detail" data-bind="visible: forecast_precip_probability">

--- a/appdaemon/widgets/weather.yaml
+++ b/appdaemon/widgets/weather.yaml
@@ -20,8 +20,8 @@ fields:
   bearing_icon: "mdi-rotate-0"
   precip_type_icon: "mdi-umbrella"
   forecast_title: ""
-  forecast_temperature: ""
-  forecast_apparent_temperature: ""
+  forecast_temperature_min: ""
+  forecast_temperature_max: ""
   forecast_icon: ""
   forecast_precip_probability: ""
   forecast_precip_type: ""
@@ -38,8 +38,8 @@ entities:
   wind_speed: sensor.dark_sky_wind_speed
   wind_bearing: sensor.dark_sky_wind_bearing
   forecast_icon: sensor.dark_sky_icon_1
-  forecast_temperature: sensor.dark_sky_temperature_1
-  forecast_apparent_temperature: sensor.dark_sky_apparent_temperature_1
+  forecast_temperature_min: sensor.dark_sky_daily_low_temperature_1
+  forecast_temperature_max: sensor.dark_sky_daily_high_temperature_1
   forecast_precip_probability: sensor.dark_sky_precip_probability_1
   forecast_precip_type: sensor.dark_sky_precip_1
 css: []

--- a/docs/DASHBOARD_CREATION.rst
+++ b/docs/DASHBOARD_CREATION.rst
@@ -717,6 +717,8 @@ monitored_conditions:
 
 -  temperature
 -  apparent\_temperature
+-  temperature_min
+-  temperature_max
 -  humidity
 -  precip\_probability
 -  precip\_intensity
@@ -773,8 +775,8 @@ Example with default values:
         wind_speed: sensor.dark_sky_wind_speed
         wind_bearing: sensor.dark_sky_wind_bearing
         forecast_icon: sensor.dark_sky_icon_1
-        forecast_temperature: sensor.dark_sky_temperature_1
-        forecast_apparent_temperature: sensor.dark_sky_apparent_temperature_1
+        forecast_temperature_min: sensor.dark_sky_daily_low_temperature_1
+        forecast_temperature_max: sensor.dark_sky_daily_high_temperature_1
         forecast_precip_probability: sensor.dark_sky_precip_probability_1
         forecast_precip_type: sensor.dark_sky_precip_1
 


### PR DESCRIPTION
I've changed the code for forcast from "forecast temperature"/"forecast apparent temperature" to "forecaset_min"/"forcast_max" as only those sensors are available from darksky