### PR TITLE
"exec" appdaemon to make it PID 1.

### DIFF
--- a/dockerStart.sh
+++ b/dockerStart.sh
@@ -43,4 +43,4 @@ if [ -n "$DASH_URL" ]; then
 fi
 
 # Lets run it!
-appdaemon -c $CONF $EXTRA_CMD
+exec appdaemon -c $CONF $EXTRA_CMD


### PR DESCRIPTION
This allows appdaemon to receive signals (e.g. SIGTERM) when Docker
tries to stop the container. As a result, appdaemon can shut down
cleanly and quickly (avoiding the 10 secs wait when PID 1 does
not handle SIGTERM.