### PR TITLE
Update to Mqtt Plugin

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -12,12 +12,13 @@ Change Log
 - Exiting from the commandline with ctrl-c will now cleanly terminate apps
 - Sending SIGTERM to an appdaemon process will cause a clean shutdown, including orderly termination of all apps in dependency order
 - Added extra checking for HASS Initialization to prevent a race condition in which metadata could not be read
-- Weather widget facelift allowing ability to change sensors, more dynamic usnits, forecast option, icon options, option to show Rain/Snow depending on precip_type sensor (and change icons), wind icon rotates acording to wind bearing - contributed by `Marcin Domański <https://github.com/kabturek>`__
+- Weather widget facelift allowing ability to change sensors, more dynamic usnits, forecast option, icon options, option to show Rain/Snow depending on precip_type sensor (and change icons), wind icon rotates according to wind bearing - contributed by `Marcin Domański <https://github.com/kabturek>`__
 
-**Fixes**
+*Fixes**
 
 - Fixed a problem in the Docker initialization script
 - Fixed an parameter collision for events with a parameter ``name`` in ``listen_event()``
+- Grammar corrections to docs, and a fix to the stop code - contributed by `Matthias Urlichs <https://github.com/smurfix>`__
 
 **Breaking Changes**
 
@@ -52,7 +53,6 @@ None
  - Fixed a bug that broke retries when connecting to Home Assistant
  - Fixed a bug that could cause lockups during app initialization
  - Fixed a bug for Docker that prevented the initial config from working correctly - contributed by `mradziwo <https://github.com/mradziwo>`__
- - Grammar corrections to docs, and a fix to the stop code - contributed by `Matthias Urlichs <https://github.com/smurfix>`__
 
 **Breaking Changes**
 


### PR DESCRIPTION
This is an update to the mqtt plugin, created by @tschmidty69 as seen [here](https://github.com/home-assistant/appdaemon/pull/238). Basically below are listed my updates:
- Ability to send data from app to mqtt broker using `self.mqtt_send(topic, payload, qos=0, retain=false, kwargs)`
- The same config declared in the `appdaemon.yaml` file, is also used in the above `self.mqtt_send`. therefore no need to declare these again
- Added some error handling mechanism so a user can know when there is an issue with subscribing
- Added `self.listen_state()` in app. This is important as if one wants to use the `self.mqtt_send`, this needs to be sent to the mqtt app using `self.set_app_state()`, which is then picked up by the app. This was also needed, in the event one wants to get state from Hass directly and send over mqtt
- And generally a few tweaks around.

On a side note, please this is my first pull request, so forgive if any thing is missed out.

Kind regards and its a honour contributing to this great project.