### PR TITLE
Yaml quotes

### DIFF
--- a/appdaemon/dashboard.py
+++ b/appdaemon/dashboard.py
@@ -248,15 +248,7 @@ class Dashboard:
                     instantiated_widget = yaml.load(widget)
                 except yaml.YAMLError as exc:
                     self._log_error(dash, name, "Error while parsing dashboard '{}':".format(yaml_path))
-                    if hasattr(exc, 'problem_mark'):
-                        if exc.context is not None:
-                            self._log_error(dash, name, "parser says")
-                            self._log_error(dash, name, str(exc.problem_mark))
-                            self._log_error(dash, name, str(exc.problem) + " " + str(exc.context))
-                        else:
-                            self._log_error(dash, name, "parser says")
-                            self._log_error(dash, name, str(exc.problem_mark))
-                            self._log_error(dash, name, str(exc.problem))
+                    self._log_yaml_error(dash, name, exc)
                     return self.error_widget("Error loading widget")
 
             elif name.find(".") != -1:
@@ -314,15 +306,7 @@ class Dashboard:
                 final_widget = yaml.load(yaml_file)
             except yaml.YAMLError as exc:
                 self._log_error(dash, name, "Error in widget definition '{}':".format(widget_type))
-                if hasattr(exc, 'problem_mark'):
-                    if exc.context is not None:
-                        self._log_error(dash, name, "parser says")
-                        self._log_error(dash, name, str(exc.problem_mark))
-                        self._log_error(dash, name, str(exc.problem) + " " + str(exc.context))
-                    else:
-                        self._log_error(dash, name, "parser says")
-                        self._log_error(dash, name, str(exc.problem_mark))
-                        self._log_error(dash, name, str(exc.problem))
+                self._log_yaml_error(dash, name, exc)
                 return self.error_widget("Error loading widget definition")
 
             #
@@ -446,6 +430,15 @@ class Dashboard:
     def _log_error(self, dash, name, error):
         dash["errors"].append("{}: {}".format(os.path.basename(name), error))
         ha.log(self.logger, "WARNING", error)
+
+    def _log_yaml_error(self, dash, name, exc):
+        if hasattr(exc, 'problem_mark'):
+            self._log_error(dash, name, "parser says")
+            self._log_error(dash, name, str(exc.problem_mark))
+            if exc.context is not None:
+                self._log_error(dash, name, str(exc.problem) + " " + str(exc.context))
+            else:
+                self._log_error(dash, name, str(exc.problem))        
 
     def _create_dash(self, name, css_vars):
         dash, layout, occupied, includes = self._create_sub_dash(name, "dash", 0, {}, [], 1, css_vars, None)

--- a/appdaemon/dashboard.py
+++ b/appdaemon/dashboard.py
@@ -131,8 +131,7 @@ class Dashboard:
             with open(yaml_path, 'r') as yamlfd:
                 css_text = yamlfd.read()
             try:
-                yaml.add_constructor('!secret', ha._secret_yaml)
-                css = yaml.load(css_text)
+                css = self._load_yaml(css_text)
             except yaml.YAMLError as exc:
                 ha.log(self.logger, "WARNING", "Error loading CSS variables")
                 self._log_yaml_error(exc)
@@ -236,8 +235,7 @@ class Dashboard:
                 with open(yaml_path, 'r') as yamlfd:
                     widget = yamlfd.read()
                 try:
-                    yaml.add_constructor('!secret', ha._secret_yaml)
-                    instantiated_widget = yaml.load(widget)
+                    instantiated_widget = self._load_yaml(widget)
                 except yaml.YAMLError as exc:
                     self._log_error(dash, name, "Error while parsing dashboard '{}':".format(yaml_path))
                     self._log_yaml_dash_error(dash, name, exc)
@@ -294,8 +292,7 @@ class Dashboard:
                 #
                 # Parse the substituted YAML file - this is a derived widget definition
                 #
-                yaml.add_constructor('!secret', ha._secret_yaml)
-                final_widget = yaml.load(yaml_file)
+                final_widget = self._load_yaml(yaml_file)
             except yaml.YAMLError as exc:
                 self._log_error(dash, name, "Error in widget definition '{}':".format(widget_type))
                 self._log_yaml_dash_error(dash, name, exc)
@@ -439,8 +436,12 @@ class Dashboard:
             if exc.context is not None:
                 lines.append(str(exc.problem) + " " + str(exc.context))
             else:
-                lines.append(str(exc.problem))
+                lines.append(str(exc.problem))         
         return lines
+    
+    def _load_yaml(self, stream):
+        yaml.add_constructor('!secret', ha._secret_yaml)
+        return yaml.load(stream)
 
     def _create_dash(self, name, css_vars):
         dash, layout, occupied, includes = self._create_sub_dash(name, "dash", 0, {}, [], 1, css_vars, None)
@@ -473,8 +474,7 @@ class Dashboard:
             return dash, layout, occupied, includes
 
         try:
-            yaml.add_constructor('!secret', ha._secret_yaml)
-            dash_params = yaml.load(defs)
+            dash_params = self._load_yaml(defs)
         except yaml.YAMLError as exc:
             self._log_error(dash, name, "Error while parsing dashboard '{}':".format(dashfile))
             self._log_yaml_dash_error(dash, name, exc)

--- a/appdaemon/dashboard.py
+++ b/appdaemon/dashboard.py
@@ -247,16 +247,16 @@ class Dashboard:
                     yaml.add_constructor('!secret', ha._secret_yaml)
                     instantiated_widget = yaml.load(widget)
                 except yaml.YAMLError as exc:
-                    _log_error(dash, name, "Error while parsing dashboard '{}':".format(yaml_path))
+                    self._log_error(dash, name, "Error while parsing dashboard '{}':".format(yaml_path))
                     if hasattr(exc, 'problem_mark'):
                         if exc.context is not None:
-                            _log_error(dash, name, "parser says")
-                            _log_error(dash, name, str(exc.problem_mark))
-                            _log_error(dash, name, str(exc.problem) + " " + str(exc.context))
+                            self._log_error(dash, name, "parser says")
+                            self._log_error(dash, name, str(exc.problem_mark))
+                            self._log_error(dash, name, str(exc.problem) + " " + str(exc.context))
                         else:
-                            _log_error(dash, name, "parser says")
-                            _log_error(dash, name, str(exc.problem_mark))
-                            _log_error(dash, name, str(exc.problem))
+                            self._log_error(dash, name, "parser says")
+                            self._log_error(dash, name, str(exc.problem_mark))
+                            self._log_error(dash, name, str(exc.problem))
                     return self.error_widget("Error loading widget")
 
             elif name.find(".") != -1:
@@ -313,16 +313,16 @@ class Dashboard:
                 yaml.add_constructor('!secret', ha._secret_yaml)
                 final_widget = yaml.load(yaml_file)
             except yaml.YAMLError as exc:
-                _log_error(dash, name, "Error in widget definition '{}':".format(widget_type))
+                self._log_error(dash, name, "Error in widget definition '{}':".format(widget_type))
                 if hasattr(exc, 'problem_mark'):
                     if exc.context is not None:
-                        _log_error(dash, name, "parser says")
-                        _log_error(dash, name, str(exc.problem_mark))
-                        _log_error(dash, name, str(exc.problem) + " " + str(exc.context))
+                        self._log_error(dash, name, "parser says")
+                        self._log_error(dash, name, str(exc.problem_mark))
+                        self._log_error(dash, name, str(exc.problem) + " " + str(exc.context))
                     else:
-                        _log_error(dash, name, "parser says")
-                        _log_error(dash, name, str(exc.problem_mark))
-                        _log_error(dash, name, str(exc.problem))
+                        self._log_error(dash, name, "parser says")
+                        self._log_error(dash, name, str(exc.problem_mark))
+                        self._log_error(dash, name, str(exc.problem))
                 return self.error_widget("Error loading widget definition")
 
             #

--- a/appdaemon/widgets/alarm.yaml
+++ b/appdaemon/widgets/alarm.yaml
@@ -1,18 +1,18 @@
 widget_type: basealarm
-entity: {{entity}}
+entity: "{{entity}}"
 initial_string: "Enter Code"
 post_service_ah:
     service: alarm_control_panel/alarm_arm_home
-    entity_id: {{entity}}
+    entity_id: "{{entity}}"
 post_service_aa:
     service: alarm_control_panel/alarm_arm_away
-    entity_id: {{entity}}
+    entity_id: "{{entity}}"
 post_service_da:
     service: alarm_control_panel/alarm_disarm
-    entity_id: {{entity}}
+    entity_id: "{{entity}}"
 post_service_tr:
     service: alarm_control_panel/alarm_trigger
-    entity_id: {{entity}}
+    entity_id: "{{entity}}"
 state_map:
   pending: Pending
   armed_home: Armed Home
@@ -20,8 +20,8 @@ state_map:
   disarmed: Disarmed
   triggered: Triggered
 fields:
-  title: {{title}}
-  title2: {{title2}}
+  title: "{{title}}"
+  title2: "{{title2}}"
   state: ""
   code: ""
 static_css:

--- a/appdaemon/widgets/binary_sensor.yaml
+++ b/appdaemon/widgets/binary_sensor.yaml
@@ -1,10 +1,10 @@
 widget_type: baseswitch
-entity: {{entity}}
+entity: "{{entity}}"
 state_active: "on"
 state_inactive: "off"
 fields:
-  title: {{title}}
-  title2: {{title2}}
+  title: "{{title}}"
+  title2: "{{title2}}"
   icon: ""
   icon_style: ""
   state_text: ""

--- a/appdaemon/widgets/camera.yaml
+++ b/appdaemon/widgets/camera.yaml
@@ -1,6 +1,6 @@
 widget_type: baseiframe
 fields:
-  title: {{title}}
+  title: "{{title}}"
   frame_src: ""
   img_src: ""
   frame_style: '{{frame_style}}'

--- a/appdaemon/widgets/climate.yaml
+++ b/appdaemon/widgets/climate.yaml
@@ -1,12 +1,12 @@
 widget_type: baseclimate
-entity: {{entity}}
+entity: "{{entity}}"
 post_service:
     service: climate/set_temperature
-    entity_id: {{entity}}
+    entity_id: "{{entity}}"
 fields:
-  title: {{title}}
-  title2: {{title2}}
-  unit: {{unit}}
+  title: "{{title}}"
+  title2: "{{title2}}"
+  unit: "{{unit}}"
   level: ""
   level2: ""
 icons: []

--- a/appdaemon/widgets/cover.yaml
+++ b/appdaemon/widgets/cover.yaml
@@ -1,17 +1,17 @@
 widget_type: baseswitch
-entity: {{entity}}
+entity: "{{entity}}"
 state_active: "open"
 state_inactive: "closed"
 enable: 1
 post_service_active:
     service: cover/open_cover
-    entity_id: {{entity}}
+    entity_id: "{{entity}}"
 post_service_inactive:
     service: cover/close_cover
-    entity_id: {{entity}}
+    entity_id: "{{entity}}"
 fields:
-  title: {{title}}
-  title2: {{title2}}
+  title: "{{title}}"
+  title2: "{{title2}}"
   icon: ""
   icon_style: ""
   state_text: ""

--- a/appdaemon/widgets/device_tracker.yaml
+++ b/appdaemon/widgets/device_tracker.yaml
@@ -6,15 +6,15 @@ enable: 0
 state_text: 1
 post_service_active:
     service: device_tracker/see
-    dev_id: {{device}}
+    dev_id: "{{device}}"
     location_name: home
 post_service_inactive:
     service: device_tracker/see
-    dev_id: {{device}}
+    dev_id: "{{device}}"
     location_name: not_home
 fields:
-  title: {{title}}
-  title2: {{title2}}
+  title: "{{title}}"
+  title2: "{{title2}}"
   icon: ""
   icon_style: ""
   state_text: ""

--- a/appdaemon/widgets/gauge.yaml
+++ b/appdaemon/widgets/gauge.yaml
@@ -1,13 +1,13 @@
 widget_type: basegauge
-entity: {{entity}}
+entity: "{{entity}}"
 low_color: $gauge_low_value_color
 med_color: $gauge_med_value_color
 high_color: $gauge_high_value_color
 bgcolor: $gauge_value_bgcolor
 color: $gauge_text_color
 fields:
-  title: {{title}}
-  title2: {{title2}}
+  title: "{{title}}"
+  title2: "{{title2}}"
   unit: ""
 static_css:
   title_style: $gauge_title_style

--- a/appdaemon/widgets/group.yaml
+++ b/appdaemon/widgets/group.yaml
@@ -1,14 +1,14 @@
 widget_type: baselight
-entity: {{entity}}
+entity: "{{entity}}"
 post_service_active:
     service: homeassistant/turn_on
-    entity_id: {{entity}}
+    entity_id: "{{entity}}"
 post_service_inactive:
     service: homeassistant/turn_off
-    entity_id: {{entity}}
+    entity_id: "{{entity}}"
 fields:
-  title: {{title}}
-  title2: {{title2}}
+  title: "{{title}}"
+  title2: "{{title2}}"
   icon: ""
   units: "%"
   level: ""

--- a/appdaemon/widgets/heater.yaml
+++ b/appdaemon/widgets/heater.yaml
@@ -1,18 +1,18 @@
 widget_type: baseheater
-icon_entity: {{icon_entity}}
-slider_entity: {{slider_entity}}
+icon_entity: "{{icon_entity}}"
+slider_entity: "{{slider_entity}}"
 post_service_active:
     service: homeassistant/turn_on
-    entity_id: {{icon_entity}}
+    entity_id: "{{icon_entity}}"
 post_service_inactive:
     service: homeassistant/turn_off
-    entity_id: {{icon_entity}}
+    entity_id: "{{icon_entity}}"
 post_service_slider_change:
     service: input_slider/select_value
-    entity_id: {{slider_entity}}
+    entity_id: "{{slider_entity}}"
 fields:
-  title: {{title}}
-  title2: {{title2}}
+  title: "{{title}}"
+  title2: "{{title2}}"
   Temperature: ""
   MinValue: "15"
   MaxValue: "25"

--- a/appdaemon/widgets/icon.yaml
+++ b/appdaemon/widgets/icon.yaml
@@ -1,8 +1,8 @@
 widget_type: baseicon
-entity: {{entity}}
+entity: "{{entity}}"
 fields:
-  title: {{title}}
-  title2: {{title2}}
+  title: "{{title}}"
+  title2: "{{title2}}"
   icon: ""
   icon_style: ""
   state_text: ""

--- a/appdaemon/widgets/iframe.yaml
+++ b/appdaemon/widgets/iframe.yaml
@@ -1,6 +1,6 @@
 widget_type: baseiframe
 fields:
-  title: {{title}}
+  title: "{{title}}"
   frame_src: ""
   img_src: ""
   frame_style: '{{frame_style}}'

--- a/appdaemon/widgets/input_boolean.yaml
+++ b/appdaemon/widgets/input_boolean.yaml
@@ -1,17 +1,17 @@
 widget_type: baseswitch
-entity: {{entity}}
+entity: "{{entity}}"
 state_active: "on"
 state_inactive: "off"
 enable: 1
 post_service_active:
     service: homeassistant/turn_on
-    entity_id: {{entity}}
+    entity_id: "{{entity}}"
 post_service_inactive:
     service: homeassistant/turn_off
-    entity_id: {{entity}}
+    entity_id: "{{entity}}"
 fields:
-  title: {{title}}
-  title2: {{title2}}
+  title: "{{title}}"
+  title2: "{{title2}}"
   icon: ""
   icon_style: ""
   state_text: ""

--- a/appdaemon/widgets/input_number.yaml
+++ b/appdaemon/widgets/input_number.yaml
@@ -1,11 +1,11 @@
 widget_type: baseinputnumber
-entity: {{entity}}
+entity: "{{entity}}"
 post_service:
     service: input_number/set_value
-    entity_id: {{entity}}
+    entity_id: "{{entity}}"
 fields:
-  title: {{title}}
-  title2: {{title2}}
+  title: "{{title}}"
+  title2: "{{title2}}"
   SliderValue: ""
   MinValue: ""
   MaxValue: ""

--- a/appdaemon/widgets/input_select.yaml
+++ b/appdaemon/widgets/input_select.yaml
@@ -1,11 +1,11 @@
 widget_type: baseselect
-entity: {{entity}}
+entity: "{{entity}}"
 post_service:
     service: input_select/select_option
-    entity_id: {{entity}}
+    entity_id: "{{entity}}"
 fields:
-  title: {{title}}
-  title2: {{title2}}
+  title: "{{title}}"
+  title2: "{{title2}}"
   inputoptions: []
   selectedoption: ""
 icons: []

--- a/appdaemon/widgets/input_slider.yaml
+++ b/appdaemon/widgets/input_slider.yaml
@@ -1,12 +1,12 @@
 widget_type: baseslider
-entity: {{entity}}
+entity: "{{entity}}"
 post_service:
     service: input_number/set_value
-    entity_id: {{entity}}
+    entity_id: "{{entity}}"
 fields:
-  title: {{title}}
-  title2: {{title2}}
-  unit: {{unit}}
+  title: "{{title}}"
+  title2: "{{title2}}"
+  unit: "{{unit}}"
   level: ""
 icons: []
 css: []

--- a/appdaemon/widgets/javascript.yaml
+++ b/appdaemon/widgets/javascript.yaml
@@ -1,7 +1,7 @@
 widget_type: basejavascript
 fields:
-  title: {{title}}
-  title2: {{title2}}
+  title: "{{title}}"
+  title2: "{{title2}}"
   icon: ""
   icon_style: ""
 icons:

--- a/appdaemon/widgets/label.yaml
+++ b/appdaemon/widgets/label.yaml
@@ -1,8 +1,8 @@
 widget_type: basedisplay
 fields:
-  title: {{title}}
-  title2: {{title2}}
-  value: {{text}}
+  title: "{{title}}"
+  title2: "{{title2}}"
+  value: "{{text}}"
   unit: ""
   state_text: ""
 static_css:

--- a/appdaemon/widgets/light.yaml
+++ b/appdaemon/widgets/light.yaml
@@ -1,14 +1,14 @@
 widget_type: baselight
-entity: {{entity}}
+entity: "{{entity}}"
 post_service_active:
     service: homeassistant/turn_on
-    entity_id: {{entity}}
+    entity_id: "{{entity}}"
 post_service_inactive:
     service: homeassistant/turn_off
-    entity_id: {{entity}}
+    entity_id: "{{entity}}"
 fields:
-  title: {{title}}
-  title2: {{title2}}
+  title: "{{title}}"
+  title2: "{{title2}}"
   icon: ""
   units: "%"
   level: ""

--- a/appdaemon/widgets/lock.yaml
+++ b/appdaemon/widgets/lock.yaml
@@ -1,17 +1,17 @@
 widget_type: baseswitch
-entity: {{entity}}
+entity: "{{entity}}"
 state_active: "unlocked"
 state_inactive: "locked"
 enable: 1
 post_service_active:
     service: lock/unlock
-    entity_id: {{entity}}
+    entity_id: "{{entity}}"
 post_service_inactive:
     service: lock/lock
-    entity_id: {{entity}}
+    entity_id: "{{entity}}"
 fields:
-  title: {{title}}
-  title2: {{title2}}
+  title: "{{title}}"
+  title2: "{{title2}}"
   icon: ""
   icon_style: ""
   state_text: ""

--- a/appdaemon/widgets/london_underground.yaml
+++ b/appdaemon/widgets/london_underground.yaml
@@ -1,8 +1,8 @@
 widget_type: basedisplay
-entity: {{entity}}
+entity: "{{entity}}"
 entity_to_sub_entity_attribute: Description
 fields:
-  title: {{title}}
+  title: "{{title}}"
   title2: ""
   value: ""
   unit: ""

--- a/appdaemon/widgets/media_player.yaml
+++ b/appdaemon/widgets/media_player.yaml
@@ -1,25 +1,25 @@
 widget_type: basemedia
-entity: {{entity}}
+entity: "{{entity}}"
 post_service_next:
     service: media_player/media_next_track
-    entity_id: {{entity}}
+    entity_id: "{{entity}}"
 post_service_previous:
     service: media_player/media_previous_track
-    entity_id: {{entity}}
+    entity_id: "{{entity}}"
 post_service_play_pause:
     service: media_player/media_play_pause
-    entity_id: {{entity}}
+    entity_id: "{{entity}}"
 post_service_pause:
     service: media_player/media_pause
-    entity_id: {{entity}}
+    entity_id: "{{entity}}"
 post_service_stop:
     service: media_player/media_stop
-    entity_id: {{entity}}
+    entity_id: "{{entity}}"
 post_service_level:
     service: media_player/volume_set
-    entity_id: {{entity}}
+    entity_id: "{{entity}}"
 fields:
-  title: {{title}}
+  title: "{{title}}"
   artist: ""
   media_title: ""
   album: ""

--- a/appdaemon/widgets/mode.yaml
+++ b/appdaemon/widgets/mode.yaml
@@ -1,13 +1,13 @@
 widget_type: baseswitch
-entity: {{entity}}
-state_active: {{mode}}
+entity: "{{entity}}"
+state_active: "{{mode}}"
 enable: 1
 post_service_active:
     service: script/turn_on
-    entity_id: {{script}}
+    entity_id: "{{script}}"
 fields:
-  title: {{title}}
-  title2: {{title2}}
+  title: "{{title}}"
+  title2: "{{title2}}"
   icon: ""
   icon_style: ""
   state_text: ""

--- a/appdaemon/widgets/navigate.yaml
+++ b/appdaemon/widgets/navigate.yaml
@@ -1,7 +1,7 @@
 widget_type: basejavascript
 fields:
-  title: {{title}}
-  title2: {{title2}}
+  title: "{{title}}"
+  title2: "{{title2}}"
   icon: ""
   icon_style: ""
 icons:

--- a/appdaemon/widgets/radial.yaml
+++ b/appdaemon/widgets/radial.yaml
@@ -1,5 +1,5 @@
 widget_type: baseradial
-entity: {{entity}}
+entity: "{{entity}}"
 fields: []
 static_css:
   widget_style: $radial_widget_style

--- a/appdaemon/widgets/reload.yaml
+++ b/appdaemon/widgets/reload.yaml
@@ -1,8 +1,8 @@
 widget_type: basejavascript
 command: location.reload(true)
 fields:
-  title: {{title}}
-  title2: {{title2}}
+  title: "{{title}}"
+  title2: "{{title2}}"
   icon: ""
   icon_style: ""
 icons:

--- a/appdaemon/widgets/rss.yaml
+++ b/appdaemon/widgets/rss.yaml
@@ -1,8 +1,8 @@
 widget_type: baserss
-entity: {{entity}}
+entity: "{{entity}}"
 fields:
-  title: {{title}}
-  title2: {{title2}}
+  title: "{{title}}"
+  title2: "{{title2}}"
   text: ""
   description: ""
 static_css:

--- a/appdaemon/widgets/scene.yaml
+++ b/appdaemon/widgets/scene.yaml
@@ -1,5 +1,5 @@
 widget_type: baseswitch
-entity: {{entity}}
+entity: "{{entity}}"
 state_inactive: "scening"
 state_active: "stillscening"
 enable: 1
@@ -7,13 +7,13 @@ momentary: 1000
 ignore_state: 1
 post_service_active:
     service: homeassistant/turn_on
-    entity_id: {{entity}}
+    entity_id: "{{entity}}"
 post_service_inactive:
     service: homeassistant/turn_off
-    entity_id: {{entity}}
+    entity_id: "{{entity}}"
 fields:
-  title: {{title}}
-  title2: {{title2}}
+  title: "{{title}}"
+  title2: "{{title2}}"
   icon: ""
   icon_style: ""
   state_text: ""

--- a/appdaemon/widgets/script.yaml
+++ b/appdaemon/widgets/script.yaml
@@ -1,5 +1,5 @@
 widget_type: baseswitch
-entity: {{entity}}
+entity: "{{entity}}"
 state_inactive: "off"
 state_active: "on"
 enable: 1
@@ -7,13 +7,13 @@ momentary: 1000
 ignore_state: 1
 post_service_active:
     service: homeassistant/turn_on
-    entity_id: {{entity}}
+    entity_id: "{{entity}}"
 post_service_inactive:
     service: homeassistant/turn_off
-    entity_id: {{entity}}
+    entity_id: "{{entity}}"
 fields:
-  title: {{title}}
-  title2: {{title2}}
+  title: "{{title}}"
+  title2: "{{title2}}"
   icon: ""
   icon_style: ""
   state_text: ""

--- a/appdaemon/widgets/sensor.yaml
+++ b/appdaemon/widgets/sensor.yaml
@@ -1,11 +1,11 @@
 widget_type: basedisplay
-entity: {{entity}}
-entity_to_sub_entity_attribute: {{entity_to_sub_entity_attribute}}
-sub_entity: {{sub_entity}}
-sub_entity_to_entity_attribute: {{sub_entity_to_entity_attribute}}
+entity: "{{entity}}"
+entity_to_sub_entity_attribute: "{{entity_to_sub_entity_attribute}}"
+sub_entity: "{{sub_entity}}"
+sub_entity_to_entity_attribute: "{{sub_entity_to_entity_attribute}}"
 fields:
-  title: {{title}}
-  title2: {{title2}}
+  title: "{{title}}"
+  title2: "{{title2}}"
   value: ""
   unit: ""
   state_text: ""

--- a/appdaemon/widgets/switch.yaml
+++ b/appdaemon/widgets/switch.yaml
@@ -1,17 +1,17 @@
 widget_type: baseswitch
-entity: {{entity}}
+entity: "{{entity}}"
 state_active: "on"
 state_inactive: "off"
 enable: 1
 post_service_active:
     service: homeassistant/turn_on
-    entity_id: {{entity}}
+    entity_id: "{{entity}}"
 post_service_inactive:
     service: homeassistant/turn_off
-    entity_id: {{entity}}
+    entity_id: "{{entity}}"
 fields:
-  title: {{title}}
-  title2: {{title2}}
+  title: "{{title}}"
+  title2: "{{title2}}"
   icon: ""
   icon_style: ""
   state_text: ""

--- a/appdaemon/widgets/temperature.yaml
+++ b/appdaemon/widgets/temperature.yaml
@@ -1,5 +1,5 @@
 widget_type: basetemperature
-entity: {{entity}}
+entity: "{{entity}}"
 fields: []
 static_css:
   widget_style: $thermo_widget_style

--- a/appdaemon/widgets/text_sensor.yaml
+++ b/appdaemon/widgets/text_sensor.yaml
@@ -1,11 +1,11 @@
 widget_type: basedisplay
-entity: {{entity}}
-entity_to_sub_entity_attribute: {{entity_to_sub_entity_attribute}}
-sub_entity: {{sub_entity}}
-sub_entity_to_entity_attribute: {{sub_entity_to_entity_attribute}}
+entity: "{{entity}}"
+entity_to_sub_entity_attribute: "{{entity_to_sub_entity_attribute}}"
+sub_entity: "{{sub_entity}}"
+sub_entity_to_entity_attribute: "{{sub_entity_to_entity_attribute}}"
 fields:
-  title: {{title}}
-  title2: {{title2}}
+  title: "{{title}}"
+  title2: "{{title2}}"
   value: ""
   unit: ""
   state_text: ""

--- a/appdaemon/widgets/weather_summary.yaml
+++ b/appdaemon/widgets/weather_summary.yaml
@@ -1,5 +1,5 @@
 widget_type: basedisplay
-sub_entity: {{entity}}
+sub_entity: "{{entity}}"
 sub_entity_to_entity_attribute: entity_picture
 state_map: 
   "/static/images/darksky/weather-pouring.svg": "&#xe009"
@@ -12,7 +12,7 @@ state_map:
   "/static/images/darksky/weather-night.svg": "&#xe02d"
   "/static/images/darksky/weather-partlycloudy.svg": "&#xe001"
 fields:
-  title: {{title}}
+  title: "{{title}}"
   title2: ""
   value: ""
   unit: ""


### PR DESCRIPTION
Fix for issue #305.

Until now, the yaml files were read line by line, replacing variables ("{{foo}}") on the fly.
If those variables contained quotes, that would easily result in an unparseable yaml file.

With this change, the yaml files are first parsed as-is. Afterwards, the resulting yaml document is traversed, replacing variables in strings. This avoids the issues with quotes completely.