### PR TITLE
Fix for onclick not working on IE11

### DIFF
--- a/appdaemon/widgets/baseclimate/baseclimate.css
+++ b/appdaemon/widgets/baseclimate/baseclimate.css
@@ -1,7 +1,3 @@
-.widget-baseclimate-{{id}} {
-	position: relative;
-}
-
 .widget-baseclimate-{{id}} .title {
 	position: absolute;
 	top: 5px;

--- a/appdaemon/widgets/baseheater/baseheater.css
+++ b/appdaemon/widgets/baseheater/baseheater.css
@@ -1,6 +1,3 @@
-.widget-baseheater-{{id}} {
-	position: relative;
-}
 .widget-baseheater-{{id}} .title {
     position: absolute;
     top: 5px;

--- a/appdaemon/widgets/baseicon/baseicon.css
+++ b/appdaemon/widgets/baseicon/baseicon.css
@@ -1,7 +1,3 @@
-.widget-baseicon-{{id}} {
-	position: relative;
-}
-
 .widget-baseicon-{{id}} .title {
 	position: absolute;
 	top: 5px;

--- a/appdaemon/widgets/baseinputnumber/baseinputnumber.css
+++ b/appdaemon/widgets/baseinputnumber/baseinputnumber.css
@@ -1,6 +1,3 @@
-.widget-baseinputnumber-{{id}} {
-	position: relative;
-}
 .widget-baseinputnumber-{{id}} .title {
     position: absolute;
     top: 5px;

--- a/appdaemon/widgets/baselight/baselight.css
+++ b/appdaemon/widgets/baselight/baselight.css
@@ -1,7 +1,3 @@
-.widget-baselight-{{id}} {
-	position: relative;
-}
-
 .widget-baselight-{{id}} .state_text {
 	font-size: 85%;
 }

--- a/appdaemon/widgets/basemedia/basemedia.css
+++ b/appdaemon/widgets/basemedia/basemedia.css
@@ -1,7 +1,3 @@
-.widget-basemedia-{{id}} {
-	position: relative;
-}
-
 .widget-basemedia-{{id}} .title {
 	position: absolute;
 	top: 5px;

--- a/appdaemon/widgets/baseselect/baseselect.css
+++ b/appdaemon/widgets/baseselect/baseselect.css
@@ -1,6 +1,3 @@
-.widget-baseselect-{{id}} {
-    position: relative;
-}
 .widget-baseselect-{{id}} .title {
     position: absolute;
     top: 5px;

--- a/appdaemon/widgets/baseslider/baseslider.css
+++ b/appdaemon/widgets/baseslider/baseslider.css
@@ -1,7 +1,3 @@
-.widget-baseslider-{{id}} {
-	position: relative;
-}
-
 .widget-baseslider-{{id}} .title {
 	position: absolute;
 	top: 5px;

--- a/appdaemon/widgets/baseswitch/baseswitch.css
+++ b/appdaemon/widgets/baseswitch/baseswitch.css
@@ -1,7 +1,3 @@
-.widget-baseswitch-{{id}} {
-	position: relative;
-}
-
 .widget-baseswitch-{{id}} .title {
 	position: absolute;
 	top: 5px;

--- a/appdaemon/widgets/basetemperature/basetemperature.css
+++ b/appdaemon/widgets/basetemperature/basetemperature.css
@@ -1,7 +1,3 @@
-.widget-basetemperature-{{id}} {
-	position: relative;
-}
-
 .widget-basetemperature-{{id}} .canvasclass {
 	position: relative;
 	vertical-align: middle;


### PR DESCRIPTION
In reference to #268, onclick event is not working for some widgets when using IE11.  Removing the position: relative property from the widgets CSS fixes this issue for IE11.