### PR TITLE
Support for lists and nested dicts on call_service

### DIFF
--- a/appdaemon/rundash.py
+++ b/appdaemon/rundash.py
@@ -343,7 +343,27 @@ class RunDash:
                         y = m.group(2)
                         args["xy_color"] = [x, y]
                 else:
-                    args[key] = data[key]
+                    # transform value into list if there's "|" 
+                    if "|" in data[key]:
+                        value = data[key].split("|")
+                    else:
+                        value = data[key]
+
+                    # check for nested dicts. 2 levels deep for now
+                    if "[" in key:
+                        newkey = key.replace("]","")
+                        newkey, subkey = newkey.split("[",1)
+                        if not newkey in args.keys():
+                           args[newkey] = {}
+                        if "[" in subkey:
+                           subkey, subsubkey = subkey.split("[")
+                           if not subkey in args[newkey].keys():
+                               args[newkey][subkey] = {}
+                           args[newkey][subkey][subsubkey] = value
+                        else:
+                           args[newkey][subkey] = value
+                    else:
+                        args[key] = value
 
             plugin = self.AD.get_plugin(namespace)
             await plugin.call_service (service, **args)


### PR DESCRIPTION
I was writing a few custom widgets to hadashboard and found that I couldn't sent lists or nested dicts while calling services to HA. I wrote a custom_widget to call HA remote.send_command. This service accepts a single command, or a list of commands. When sending a list of commands, HA expects a json with the commands as a list, like: "commands": [ "cmd1", "cmd2", "cmd3" ]. So i modified the rundash.py call_service function to transform a "value" string with "|" separators into a list. Below is a example of a remote widget (snippet):

custom_widget/remote.yaml:
widget_type: baseswitch
entity: {{entity}}
...
post_service_active:
    service: remote/send_command
    entity_id: {{entity}}
    command: {{mycommand}}
post_service_inactive:
    service: remote/send_command
    command: {{mycommand}}

and a widget definition using a command list:
net_ch_mychannel:
   widget_type: remote
   title: My 3 digit channel
   entity: remote.living_room_remote
   mycommand: cable_5|cable_1|cable_2
   icon_on: mdi-television-box
   icon_off: mdi-television-box

Some HA services expects a dictionary. If you want to send parameters to  script.turn_on, HA expects a dictionary of parameters under the "variables" key, like this { "variables": { "parameter1": "value1", "parameter2": "value2" } }. Here's my "script with parameters" widget:

custom_widget/script_parameters.yaml:
widget_type: baseswitch
entity: {{entity}}
...
post_service_active:
    service: script/turn_on
    entity_id: {{entity}}
    variables:
      parameter1: {{myparameter1}}
      parameter2: {{myparameter2}}

and a widget definition:
net_msg:
   widget_type: script_parameters
   title: Send a Message
   entity: script.messagelyra
   myparameter1: hey
   myparameter2: look this!

and the companion HA script:
messagelyra:
  sequence:
    - service: notify.Lyra
      data_template:
          title: "{{ parameter1 }}"
          message: "{{ parameter2 }}"

