### PR TITLE
"self.set_app_state" Hassapi

### DIFF
--- a/appdaemon/plugins/hass/hassapi.py
+++ b/appdaemon/plugins/hass/hassapi.py
@@ -152,8 +152,8 @@ class Hass(appapi.AppDaemon):
             "set_app_state: {}, {}".format(entity_id, kwargs)
         )
 
-        if entity_id in self.get_state():
-            new_state = self.get_state()[entity_id]
+        if entity_id in self.get_state(namespace = namespace):
+            new_state = self.get_state(namespace = namespace)[entity_id]
         else:
             # Its a new state entry
             new_state = {}
@@ -162,8 +162,11 @@ class Hass(appapi.AppDaemon):
         if "state" in kwargs:
             new_state["state"] = kwargs["state"]
 
-        if "attributes" in kwargs:
-            new_state["attributes"].update(kwargs["attributes"])
+        if "attributes" in kwargs and kwargs.get('replace', False):
+            new_state["attributes"] = kwargs["attributes"]
+        else:
+            if "attributes" in kwargs:
+                new_state["attributes"].update(kwargs["attributes"])
 
         # Update AppDaemon's copy
 


### PR DESCRIPTION
Added namespace to the `self.get_state()` function within `self.set_app_state()`. Due to it not being there, it wasn't possible to properly edit an AppD entity in a different `namespace` outside that of Hass using `self.set_app_state()`, since it couldn't get the entity due to the namespace missing in the `self.get_state`.

Also added the "replace" flag in `self.set_app_state()`. As it was sometimes necessary (at least for me) to have all the data in the entity changed (like if wanting to delete some keys within attributes), rather than being updated. So if the "replace" flag is given, and is `True`, rather than update the attributes, it will replace the entire attributes dictionary with what was given.

By doing the above, in the app, one can read all attributes, modify as needed and decide to replace everything like removing keys.

Regards