### PR TITLE
Install additional requirements during dockerStart.sh

### DIFF
--- a/dockerStart.sh
+++ b/dockerStart.sh
@@ -42,5 +42,8 @@ if [ -n "$DASH_URL" ]; then
   fi
 fi
 
+#check recursively under CONF for additional python dependencies defined in requirements.txt
+find $CONF -name requirements.txt -exec pip3 install -r {} \;
+
 # Lets run it!
 appdaemon -c $CONF $EXTRA_CMD


### PR DESCRIPTION
Check recursively under CONF for additional python dependencies defined in requirements.txt and install them
Implements https://github.com/home-assistant/appdaemon/issues/235