### PR TITLE
Add an equals sign to match other optional args

### DIFF
--- a/docs/APIREFERENCE.rst
+++ b/docs/APIREFERENCE.rst
@@ -195,7 +195,7 @@ When called, AppDaemon will supply the callback function, in old and
 new, with the state attribute for that entity, e.g. ``on`` or ``off``
 for a light.
 
-attribute (optional)
+attribute =  (optional)
 ''''''''''''''''''''
 
 Name of an attribute within the entity state object. If this parameter


### PR DESCRIPTION
Other optional args have an = sign after them, but attribute doesn't