### PR TITLE
Added --upgrade to pip3 call for recursive requirements.txt scanning

### DIFF
--- a/dockerStart.sh
+++ b/dockerStart.sh
@@ -43,7 +43,7 @@ if [ -n "$DASH_URL" ]; then
 fi
 
 #check recursively under CONF for additional python dependencies defined in requirements.txt
-find $CONF -name requirements.txt -exec pip3 install -r {} \;
+find $CONF -name requirements.txt -exec pip3 install --upgrade -r {} \;
 
 # Lets run it!
 exec appdaemon -c $CONF $EXTRA_CMD


### PR DESCRIPTION
Without this flag, packages that are not pinned to specific versions in requirements.txt (like e.g. ``hass-apps``) don't stay up to date. This does of course not affect packages that have a fixed version set like ``hass-apps==0.20180824.1``.
