### PR TITLE
Update hassapi.py

### DIFF
--- a/appdaemon/plugins/hass/hassapi.py
+++ b/appdaemon/plugins/hass/hassapi.py
@@ -207,7 +207,7 @@ class Hass(appapi.AppDaemon):
         msg = self._sub_stack(msg)
         self.AD.err(level, msg, self.name)
 
-    def get_hass_config(self, **kwargs):
+    def get_config(self, **kwargs):
         namespace = self._get_namespace(**kwargs)
         return self.AD.get_plugin_meta(namespace)
 

--- a/appdaemon/plugins/hass/hassapi.py
+++ b/appdaemon/plugins/hass/hassapi.py
@@ -208,7 +208,7 @@ class Hass(appapi.AppDaemon):
         msg = self._sub_stack(msg)
         self.AD.err(level, msg, self.name)
 
-    def get_config(self, **kwargs):
+    def get_plugin_config(self, **kwargs):
         namespace = self._get_namespace(**kwargs)
         return self.AD.get_plugin_meta(namespace)
 

--- a/appdaemon/plugins/hass/hassapi.py
+++ b/appdaemon/plugins/hass/hassapi.py
@@ -105,8 +105,8 @@ class Hass(appapi.AppDaemon):
             "set_state: {}, {}".format(entity_id, kwargs)
         )
 
-        if entity_id in self.get_state():
-            new_state = self.get_state()[entity_id]
+        if entity_id in self.get_state(namespace = namespace):
+            new_state = self.get_state(namespace = namespace)[entity_id]
         else:
             # Its a new state entry
             new_state = {}
@@ -152,8 +152,8 @@ class Hass(appapi.AppDaemon):
             "set_app_state: {}, {}".format(entity_id, kwargs)
         )
 
-        if entity_id in self.get_state():
-            new_state = self.get_state()[entity_id]
+        if entity_id in self.get_state(namespace = namespace):
+            new_state = self.get_state(namespace = namespace)[entity_id]
         else:
             # Its a new state entry
             new_state = {}
@@ -162,8 +162,11 @@ class Hass(appapi.AppDaemon):
         if "state" in kwargs:
             new_state["state"] = kwargs["state"]
 
-        if "attributes" in kwargs:
-            new_state["attributes"].update(kwargs["attributes"])
+        if "attributes" in kwargs and kwargs.get('replace', False):
+            new_state["attributes"] = kwargs["attributes"]
+        else:
+            if "attributes" in kwargs:
+                new_state["attributes"].update(kwargs["attributes"])
 
         # Update AppDaemon's copy
 
@@ -172,8 +175,6 @@ class Hass(appapi.AppDaemon):
         return new_state
 
     def entity_exists(self, entity_id, **kwargs):
-        if "namespace" in kwargs:
-            del kwargs["namespace"]
         namespace = self._get_namespace(**kwargs)
         return self.AD.entity_exists(namespace, entity_id)
 


### PR DESCRIPTION
Changed `get_hass_config()`, to `get_config()`. Reason being that when working on another plugin, and want to get the config, using `get_hass_config()` seems a bit off

Also added `namespace` to the `self.get_state()` function within `set_app_state()`, `set_state()` and `entity_exists()` functions. Due to it not being there, it wasn't possible to properly edit an AppD or a different HASS entity in a different `namespace` outside that of Hass namespace the app was operating in. For example using `self.set_app_state(namespace = 'mqtt')` or `self.entity_exists(namespace = 'hass2')`, since it couldn't get the entity due to the namespace missing in the `self.get_state()` function.

Also added the `replace` flag in `set_app_state()`. As it was sometimes necessary (at least for me) to have all the data in the entity changed (like if wanting to delete some keys within attributes), rather than being updated. So if the `replace` flag is given, and is True, rather than update the attributes, it will replace the entire attributes dictionary with what was given. By doing this in the app, one can read all attributes, modify as needed and decide to replace everything like removing keys.

Regards