### PR TITLE
Fix a typo in the example systemd service

### DIFF
--- a/docs/INSTALL.rst
+++ b/docs/INSTALL.rst
@@ -201,7 +201,7 @@ Assistant with is a good choice.
     After=home-assistant@homeassistant.service
     [Service]
     Type=simple
-    User=%1
+    User=%I
     ExecStart=/usr/local/bin/appdaemon -c <full path to config directory>
     [Install]
     WantedBy=multi-user.target


### PR DESCRIPTION
The way it's written it always starts as `root` and the service parameter is not used, so I guess that's just a typo.