### PR TITLE
Update mqttapi.py

### DIFF
--- a/appdaemon/plugins/mqtt/mqttapi.py
+++ b/appdaemon/plugins/mqtt/mqttapi.py
@@ -22,7 +22,7 @@ class Mqtt(appapi.AppDaemon):
 
         super(Mqtt, self).__init__(ad, name, logger, error, args, config, app_config, global_vars)
 
-        self.namespace = "mqtt"
+        self.namespace = "default"
         self.AD = ad
         self.name = name
         self._logger = logger


### PR DESCRIPTION
Changed default `namespace` from "mqtt" to "default"