### PR TITLE
fix:"namesspace" typo introduced in #392

### DIFF
--- a/appdaemon/plugins/hass/hassapi.py
+++ b/appdaemon/plugins/hass/hassapi.py
@@ -337,7 +337,7 @@ class Hass(appapi.AppDaemon):
             rargs = kwargs
             rargs["entity_id"] = entity_id
             
-        rargs["namespace"] = namesspace
+        rargs["namespace"] = namespace
         self.call_service("homeassistant/turn_on", **rargs)
 
     @hass_check
@@ -353,7 +353,7 @@ class Hass(appapi.AppDaemon):
             rargs = kwargs
             rargs["entity_id"] = entity_id
 
-        rargs["namespace"] = namesspace
+        rargs["namespace"] = namespace
         device, entity = self.split_entity(entity_id)
         if device == "scene":
             self.call_service("homeassistant/turn_on", **rargs)
@@ -373,7 +373,7 @@ class Hass(appapi.AppDaemon):
             rargs = kwargs
             rargs["entity_id"] = entity_id
             
-        rargs["namespace"] = namesspace
+        rargs["namespace"] = namespace
         self.call_service("homeassistant/toggle", **rargs)
 
     @hass_check
@@ -389,7 +389,7 @@ class Hass(appapi.AppDaemon):
             rargs = kwargs
             rargs["entity_id"] = entity_id
             rargs["value"] = value
-        rargs["namespace"] = namesspace
+        rargs["namespace"] = namespace
         self.call_service("input_number/set_value", **rargs)
 
     @hass_check
@@ -406,7 +406,7 @@ class Hass(appapi.AppDaemon):
             rargs["entity_id"] = entity_id
             rargs["value"] = value
             
-        rargs["namespace"] = namesspace
+        rargs["namespace"] = namespace
         self.call_service("input_text/set_value", **rargs)
 
     @hass_check
@@ -423,7 +423,7 @@ class Hass(appapi.AppDaemon):
             rargs["entity_id"] = entity_id
             rargs["option"] = option
             
-        rargs["namespace"] = namesspace
+        rargs["namespace"] = namespace
         self.call_service("input_select/select_option", **rargs)
 
     @hass_check


### PR DESCRIPTION
A typo in pull request #392 was introduced when attempting to add
namespace support for HASS service calls using a namespace.

There is a mismatch in the variable definition on the first line of
each corresponding function and the consumption of that variable in the
assignment of `rargs["namespace"]`, e.g.:

https://github.com/home-assistant/appdaemon/blob/ef10b619fc7434455df7f7fde2321c8b0e0b0acf/appdaemon/plugins/hass/hassapi.py#L328-L341

When used with `occusim.py` this results in an error of the following
sort:

```
2018-10-29 22:23:54.085306 WARNING AppDaemon: ------------------------------------------------------------
2018-10-29 22:23:54.087766 WARNING AppDaemon: Traceback (most recent call last):
  File "/opt/appdaemon3-python3.6.5/lib/python3.6/site-packages/appdaemon/appdaemon.py", line 586, in worker
    funcref(self.sanitize_timer_kwargs(app, args["kwargs"]))
  File "/home/homeassistant/.appdaemon/apps/occusim.py", line 222, in execute_step
    self.activate(kwargs[arg], "off")
  File "/home/homeassistant/.appdaemon/apps/occusim.py", line 244, in activate
    if not self.test: self.turn_off(entity)
  File "/opt/appdaemon3-python3.6.5/lib/python3.6/site-packages/appdaemon/plugins/hass/hassapi.py", line 22, in func_wrapper
    return func(*args, **kwargs)
  File "/opt/appdaemon3-python3.6.5/lib/python3.6/site-packages/appdaemon/plugins/hass/hassapi.py", line 356, in turn_off
    rargs["namespace"] = namesspace
NameError: name 'namesspace' is not defined
```

This commit resolves the typo and has been tested on `dev` to resolve
the issue.