### PR TITLE
Notify Plugin Stopped Bug

### DIFF
--- a/appdaemon/plugins/mqtt/mqttplugin.py
+++ b/appdaemon/plugins/mqtt/mqttplugin.py
@@ -294,7 +294,7 @@ class MqttPlugin:
                     self.initialized = True
                 else:
                     if not already_notified and already_initialized:
-                        self.AD.notify_plugin_stopped(self.name, meta, state, self.namespace)
+                        self.AD.notify_plugin_stopped(self.name, self.namespace)
                         self.AD.log("CRITICAL", "{}: MQTT Plugin Stopped Unexpectedly".format(self.name))
                         already_notified = True
                         already_initialized = False


### PR DESCRIPTION
Extra arguments were given for the `notify_plugin_stopped` function as when the state and metadata were added to the plugin started, it was erroneously added to plugin stopped which made AD to break