### PR TITLE
Bug fix for when Disconnected then Reonnects

### DIFF
--- a/appdaemon/plugins/mqtt/mqttplugin.py
+++ b/appdaemon/plugins/mqtt/mqttplugin.py
@@ -169,6 +169,8 @@ class MqttPlugin(PluginBase):
                 self.logger.critical("MQTT Client Disconnected Abruptly. Will attempt reconnection")
                 self.logger.debug("Return code: %s", rc)
                 self.logger.debug("userdata: %s", userdata)
+                self.initialized = False
+                self.mqtt_connected = False
             return
         except:
             self.logger.critical("There was an error while disconnecting from the Mqtt Service")


### PR DESCRIPTION
This fix fixes an issue whereby when the plugin disconnects and reconnects, it processes a plugin restart