### PR TITLE
title2_is_friendly_name

### DIFF
--- a/appdaemon/assets/javascript/dashboard.js
+++ b/appdaemon/assets/javascript/dashboard.js
@@ -234,6 +234,12 @@ var WidgetBase = function(widget_id, url, skin, parameters, monitored_entities, 
                             {
                                 child.ViewModel.title(new_state.attributes.friendly_name)
                             }
+                            if ("title2_is_friendly_name" in child.parameters 
+                            && child.parameters.title2_is_friendly_name === 1
+                            && "friendly_name" in new_state.attributes)
+                            {
+                                child.ViewModel.title2(new_state.attributes.friendly_name)
+                            }
                             if (typeof child.entity_state === 'undefined')
                             {
                                 child.entity_state = {}

--- a/docs/DASHBOARD_CREATION.rst
+++ b/docs/DASHBOARD_CREATION.rst
@@ -539,6 +539,21 @@ One wrinkle here is that YAML over enthusiastically "helps" by
 interpreting things like ``on`` and ``off`` as booleans so the quotes
 are needed to prevent this.
 
+Titles
+------
+
+Each widget could have custom text for title a title2. You can use option to force widget to use text from entity friendly name attribute.
+
+-  ``title_is_friendly_name`` - set title as entity friendly name if exists
+-  ``title2_is_friendly_name`` - set title2 as entity friendly name if exists
+
+Example:
+ 
+.. code:: yaml
+
+    title_is_friendly_name: 1
+    title2_is_friendly_name: 1
+    
 Icons
 -----
 


### PR DESCRIPTION
Ability to set title2 as entity friendly name, similar to title_is_friendly_name
This option is still undocumented and hidden common users