### PR TITLE
Added optional default=None parameter to get_state().

### DIFF
--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -319,12 +319,12 @@ class ADAPI:
         self.logger.debug("Calling info_listen_state for %s",self.name)
         return utils.run_coroutine_threadsafe(self, self.AD.state.info_state_callback(handle, self.name))
 
-    def get_state(self, entity_id=None, attribute=None, **kwargs):
+    def get_state(self, entity_id=None, attribute=None, default=None, **kwargs):
         namespace = self._get_namespace(**kwargs)
         if "namespace" in kwargs:
             del kwargs["namespace"]
 
-        return utils.run_coroutine_threadsafe(self, self.AD.state.get_state(self.name, namespace, entity_id, attribute, **kwargs))
+        return utils.run_coroutine_threadsafe(self, self.AD.state.get_state(self.name, namespace, entity_id, attribute, default, **kwargs))
 
     def set_state(self, entity_id, **kwargs):
         self.logger.debug("set state: %s, %s", entity_id, kwargs)

--- a/appdaemon/state.py
+++ b/appdaemon/state.py
@@ -276,13 +276,15 @@ class State:
 
         await self.AD.events.process_event(namespace, data)
 
-    async def get_state(self, name, namespace, entity_id=None, attribute=None):
-        self.logger.debug("get_state: %s.%s", entity_id, attribute)
+    async def get_state(
+            self, name, namespace, entity_id=None, attribute=None, default=None
+    ):
+        self.logger.debug("get_state: %s.%s %s", entity_id, attribute, default)
         device = None
         entity = None
         if entity_id is not None and "." in entity_id:
             if not await self.entity_exists(namespace, entity_id):
-                return None
+                return default
         if entity_id is not None:
             if "." not in entity_id:
                 if attribute is not None:
@@ -307,14 +309,14 @@ class State:
             if entity_id in self.state[namespace] and "state" in self.state[namespace][entity_id]:
                 return deepcopy(self.state[namespace][entity_id]["state"])
             else:
-                return None
+                return default
         else:
             entity_id = "{}.{}".format(device, entity)
             if attribute == "all":
                 if entity_id in self.state[namespace]:
                     return deepcopy(self.state[namespace][entity_id])
                 else:
-                    return None
+                    return default
             else:
                 if namespace in self.state and entity_id in self.state[namespace]:
                     if attribute in self.state[namespace][entity_id]["attributes"]:
@@ -323,9 +325,9 @@ class State:
                     elif attribute in self.state[namespace][entity_id]:
                         return deepcopy(self.state[namespace][entity_id][attribute])
                     else:
-                        return None
+                        return default
                 else:
-                    return None
+                    return default
 
     def parse_state(self, entity_id, namespace, **kwargs):
         self.logger.debug("parse_state: %s, %s", entity_id, kwargs)

--- a/docs/AD_API_REFERENCE.rst
+++ b/docs/AD_API_REFERENCE.rst
@@ -42,7 +42,7 @@ Synopsis
 
 .. code:: python
 
-    get_state(entity=None, attribute=None, namespace=None)
+    get_state(entity=None, attribute=None, default=None, namespace=None)
 
 ``get_state()`` is used to query the state of any component within Home
 Assistant. State updates are continuously tracked so this call runs
@@ -52,9 +52,10 @@ and as such is very efficient.
 Returns
 ^^^^^^^
 
-``get_state()`` returns a ``dictionary`` or single value, the structure
-of which varies according to the parameters used. If an entity or
-attribute does not exist, ``get_state()`` will return ``None``.
+``get_state()`` returns a ``dictionary`` or single value, the structure of
+which varies according to the parameters used. If an entity or attribute
+does not exist, ``get_state()`` will return the value given as the
+``default``.
 
 Parameters
 ^^^^^^^^^^
@@ -81,12 +82,17 @@ attribute
 
 Name of an attribute within the entity state object. If this parameter
 is specified in addition to a fully qualified ``entity_id``, a single
-value representing the attribute will be returned, or ``None`` if it is
-not present.
+value representing the attribute will be returned.
 
 The value ``all`` for attribute has special significance and will return
 the entire state dictionary for the specified entity rather than an
 individual attribute value.
+
+default
+'''''''
+
+The value to return when the requested attribute or the whole entity
+doesn't exist. It defaults to ``None``.
 
 namespace
 '''''''''


### PR DESCRIPTION
Its value is returned for missing entities/attributes. This is handy when you e.g. expect a ``float`` to be returned and need to account for missing entities.

Without this, you have to do:

    get_state("climate.living", attribute="temperature") or 20

to be sure you get a ``float``, but you can't easily distinguish between ``0``, ``False`` and ``None``.

What do you think about it?