### PR TITLE
Allowed for Passing kwargs to Run_in_thread

### DIFF
--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -619,8 +619,8 @@ class ADAPI:
     #
     # Other
     #
-    def run_in_thread(self, callback, thread):
-        self.run_in(callback, 0, pin=False, pin_thread=thread)
+    def run_in_thread(self, callback, thread, **kwargs):
+        self.run_in(callback, 0, pin=False, pin_thread=thread, **kwargs)
 
     def get_thread_info(self):
         return utils.run_coroutine_threadsafe(self, self.AD.threading.get_thread_info())


### PR DESCRIPTION
Added the ability to add key worded arguments to the `run_in_thread` api, so these can be used within the function that is to be executed