### PR TITLE
Change Docker base image to alpine linux

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,9 @@
 .git
+.gitignore
+
 Dockerfile
+.dockerignore
+
+*.md
+*.rst
+docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,4 @@
-FROM python:3.6
-
-VOLUME /conf
-VOLUME /certs
-EXPOSE 5050
+FROM python:3.7-alpine
 
 # Environment vars we can configure against
 # But these are optional, so we won't define them now
@@ -11,14 +7,28 @@ EXPOSE 5050
 #ENV DASH_URL http://hass:5050
 #ENV EXTRA_CMD -D DEBUG
 
+# API Port
+EXPOSE 5050
+
+# Mountpoints for configuration & certificates
+VOLUME /conf
+VOLUME /certs
+
 # Copy appdaemon into image
-RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 COPY . .
 
-# Install
-RUN pip3 install .
+# Fix for current dev branch
+RUN pip3 install --no-cache-dir python-dateutil
+
+# Install dependencies
+RUN apk add --no-cache --virtual build-dependencies gcc libffi-dev musl-dev \
+    && pip3 install --no-cache-dir . \
+    && apk del build-dependencies
+
+# Install additional packages
+RUN apk add --no-cache curl
 
 # Start script
 RUN chmod +x /usr/src/app/dockerStart.sh
-ENTRYPOINT [ "./dockerStart.sh" ]
+ENTRYPOINT ["./dockerStart.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ VOLUME /certs
 WORKDIR /usr/src/app
 COPY . .
 
+# Install timezone data
+RUN apk add tzdata
+
 # Fix for current dev branch
 RUN pip3 install --no-cache-dir python-dateutil
 


### PR DESCRIPTION
Hey, this PR should start a discussion if a full blown debian as base image for appdaemon is really needed?! 
The Dockerfile in this PR uses alpine linux as base image which reduces the size dramatically (~380MB vs. 52MB) and probably also improves the performance (to build and run) slightly (just my personal feeling, no tests or numbers about this).

I added _curl_ to the image as it is often used by Docker healthchecks and not available in a plain alpine linux. Via this mechanism and for example Docker Build-Args, custom alpine packages (and also pip ones) could easily be added by the user if needed.
The changes to the _.dockerignore_ mentioned by @efficiosoft in #482 are also integrated here, thanks!
Python 3.7 is used here (for personal reasons) but it was also built and tested with Python 3.6 without any problems.

I personally use this since few weeks and have not seen any negative effects right now. But as this highly depends on the apps run, more testers are needed ;)

Images for quick testing are available on [dockerhub benleb/appdaemon-alpine](https://cloud.docker.com/repository/docker/benleb/appdaemon-alpine) for the current _dev_ and _3.0.2_ or can be built with your favorite _docker build_ command.