### PR TITLE
code example type-o

### DIFF
--- a/docs/AD_API_REFERENCE.rst
+++ b/docs/AD_API_REFERENCE.rst
@@ -573,10 +573,10 @@ Examples
 
 .. code:: python
 
-     Run daily at 7pm
+    # Run daily at 7pm
     import datetime
     ...
-    time = datetime.time(19, 0, 0)
+    runtime = datetime.time(19, 0, 0)
     self.run_daily(self.run_daily_c, runtime)
 
 run\_hourly()


### PR DESCRIPTION
I've noticed these over the years in the docs. I think there are other similar issues but figured I'd start with this one.