### PR TITLE
fix kwargs handling by using pop instead of get

### DIFF
--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -65,11 +65,10 @@ class ADAPI:
     def _log(self, logger, msg, *args, **kwargs):
         msg = self._sub_stack(msg)
         if "level" in kwargs:
-            level = kwargs.get("level", "INFO")
-            kwargs.pop("level")
+            level = kwargs.pop("level", "INFO")
         else:
             level = "INFO"
-        ascii_encode = kwargs.get("ascii_encode", True)
+        ascii_encode = kwargs.pop("ascii_encode", True)
         if ascii_encode is True:
             safe_enc = lambda s: str(s).encode("utf-8", "replace").decode("ascii", "replace")
             msg = safe_enc(msg)


### PR DESCRIPTION
without popping 'ascii_encode', it gets hand over to the python logger which then complains about an unexpected keyword...

```
  ...
  File "/usr/local/lib/python3.7/logging/__init__.py", line 1449, in log
    self._log(level, msg, args, **kwargs)
TypeError: _log() got an unexpected keyword argument 'ascii_encode'```