### PR TITLE
Fix run_once when comparing event with now

### DIFF
--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -486,12 +486,12 @@ class ADAPI:
         now = self.get_now()
         today = now.date()
         event = datetime.datetime.combine(today, when)
+        aware_event = self.AD.sched.convert_naive(event)
         if event < now:
             one_day = datetime.timedelta(days=1)
             event = event + one_day
-        exec_time = event.timestamp()
         handle = utils.run_coroutine_threadsafe(self, self.AD.sched.insert_schedule(
-            name, exec_time, callback, False, None, **kwargs
+            name, aware_event, callback, False, None, **kwargs
         ))
         return handle
 

--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -479,7 +479,7 @@ class ADAPI:
         if type(start) == datetime.time:
             when = start
         elif type(start) == str:
-            when = utils.run_coroutine_threadsafe(self, self.AD.sched._parse_time(start, self.name, True))["datetime"].time()
+            when = utils.run_coroutine_threadsafe(self, self.AD.sched._parse_time(start, self.name))["datetime"].time()
         else:
             raise ValueError("Invalid type for start")
         name = self.name

--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -487,9 +487,9 @@ class ADAPI:
         today = now.date()
         event = datetime.datetime.combine(today, when)
         aware_event = self.AD.sched.convert_naive(event)
-        if event < now:
+        if aware_event < now:
             one_day = datetime.timedelta(days=1)
-            event = event + one_day
+            aware_event = aware_event + one_day
         handle = utils.run_coroutine_threadsafe(self, self.AD.sched.insert_schedule(
             name, aware_event, callback, False, None, **kwargs
         ))


### PR DESCRIPTION
The event datetime object is naive in the run_once function. It needs to be converted to aware_event before comparing it with now.