### PR TITLE
Update to Save_namespace and Remove_entity

### DIFF
--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -63,7 +63,6 @@ class ADAPI:
     #
 
     def _log(self, logger, msg, *args, **kwargs):
-        msg = self._sub_stack(msg)
         if "level" in kwargs:
             level = kwargs.get("level", "INFO")
             kwargs.pop("level")
@@ -83,6 +82,9 @@ class ADAPI:
             kwargs.pop("log")
         else:
             logger = self.logger
+            
+        msg = self._sub_stack(msg)
+        
         self._log(logger, msg, *args, **kwargs)
 
     def error(self, msg, *args, **kwargs):
@@ -185,6 +187,11 @@ class ADAPI:
     def split_entity(self, entity_id, **kwargs):
         self._check_entity(self._get_namespace(**kwargs), entity_id)
         return entity_id.split(".")
+    
+    def remove_entity(self, entity_id, **kwargs):
+        namespace = self._get_namespace(**kwargs)
+        utils.run_coroutine_threadsafe(self, self.AD.state.remove_entity(namespace, entity_id))
+        return None
 
     def split_device_list(self, list_):
         return list_.split(",")

--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -157,7 +157,8 @@ class ADAPI:
     def list_namespaces(self):
         return utils.run_coroutine_threadsafe(self, self.AD.state.list_namespaces())
 
-    def save_namespace(self, namespace):
+    def save_namespace(self, **kwargs):
+        namespace = self._get_namespace(**kwargs)
         utils.run_coroutine_threadsafe(self, self.AD.state.save_namespace(namespace))
 
     #


### PR DESCRIPTION
Added key worded arguments to `save_namespace`, so once the app level namespace is declared using `set_namespace`, when using `self.save_namespace`, no need to start declaring the namespace again. 

Also if another namespace is required, by simply following other AD conventions of declaring namespace `namespace = namespace` , its use becomes in line with other AD apis.