### PR TITLE
Fix !secret tag parsing with pyyaml>3.13

### DIFF
--- a/appdaemon/admain.py
+++ b/appdaemon/admain.py
@@ -177,11 +177,11 @@ class ADMain():
             #
             # Initially load file to see if secret directive is present
             #
-            yaml.add_constructor('!secret', utils._dummy_secret)
+            yaml.add_constructor('!secret', utils._dummy_secret, Loader=yaml.SafeLoader)
             with open(config_file_yaml, 'r') as yamlfd:
                 config_file_contents = yamlfd.read()
 
-            config = yaml.load(config_file_contents)
+            config = yaml.load(config_file_contents, Loader=yaml.SafeLoader)
 
             if "secrets" in config:
                 secrets_file = config["secrets"]
@@ -195,7 +195,7 @@ class ADMain():
                 with open(secrets_file, 'r') as yamlfd:
                     secrets_file_contents = yamlfd.read()
 
-                utils.secrets = yaml.load(secrets_file_contents)
+                utils.secrets = yaml.load(secrets_file_contents, Loader=yaml.SafeLoader)
 
             else:
                 if "secrets" in config:
@@ -205,12 +205,12 @@ class ADMain():
             #
             # Read config file again, this time with secrets
             #
-            yaml.add_constructor('!secret', utils._secret_yaml)
+            yaml.add_constructor('!secret', utils._secret_yaml, Loader=yaml.SafeLoader)
 
             with open(config_file_yaml, 'r') as yamlfd:
                 config_file_contents = yamlfd.read()
 
-            config = yaml.load(config_file_contents)
+            config = yaml.load(config_file_contents, Loader=yaml.SafeLoader)
 
         except yaml.YAMLError as exc:
             print("ERROR", "Error loading configuration")

--- a/appdaemon/appdaemon.py
+++ b/appdaemon/appdaemon.py
@@ -1677,7 +1677,7 @@ class AppDaemon:
                 config_file_contents = yamlfd.read()
 
             try:
-                new_config = yaml.load(config_file_contents)
+                new_config = yaml.load(config_file_contents, Loader=yaml.SafeLoader)
 
             except yaml.YAMLError as exc:
                 self.log("WARNING", "Error loading configuration")

--- a/appdaemon/dashboard.py
+++ b/appdaemon/dashboard.py
@@ -135,8 +135,8 @@ class Dashboard:
             with open(yaml_path, 'r') as yamlfd:
                 css_text = yamlfd.read()
             try:
-                yaml.add_constructor('!secret', ha._secret_yaml)
-                css = yaml.load(css_text)
+                yaml.add_constructor('!secret', ha._secret_yaml, Loader=yaml.SafeLoader)
+                css = yaml.load(css_text, Loader=yaml.SafeLoader)
             except yaml.YAMLError as exc:
                 ha.log(self.logger, "WARNING", "Error loading CSS variables")
                 if hasattr(exc, 'problem_mark'):
@@ -248,8 +248,8 @@ class Dashboard:
                 with open(yaml_path, 'r') as yamlfd:
                     widget = yamlfd.read()
                 try:
-                    yaml.add_constructor('!secret', ha._secret_yaml)
-                    instantiated_widget = yaml.load(widget)
+                    yaml.add_constructor('!secret', ha._secret_yaml, Loader=yaml.SafeLoader)
+                    instantiated_widget = yaml.load(widget, Loader=yaml.SafeLoader)
                 except yaml.YAMLError as exc:
                     _log_error(dash, name, "Error while parsing dashboard '{}':".format(yaml_path))
                     if hasattr(exc, 'problem_mark'):
@@ -314,8 +314,8 @@ class Dashboard:
                 #
                 # Parse the substituted YAML file - this is a derived widget definition
                 #
-                yaml.add_constructor('!secret', ha._secret_yaml)
-                final_widget = yaml.load(yaml_file)
+                yaml.add_constructor('!secret', ha._secret_yaml, Loader=yaml.SafeLoader)
+                final_widget = yaml.load(yaml_file, Loader=yaml.SafeLoader)
             except yaml.YAMLError as exc:
                 _log_error(dash, name, "Error in widget definition '{}':".format(widget_type))
                 if hasattr(exc, 'problem_mark'):
@@ -482,8 +482,8 @@ class Dashboard:
             return dash, layout, occupied, includes
 
         try:
-            yaml.add_constructor('!secret', ha._secret_yaml)
-            dash_params = yaml.load(defs)
+            yaml.add_constructor('!secret', ha._secret_yaml, Loader=yaml.SafeLoader)
+            dash_params = yaml.load(defs, Loader=yaml.SafeLoader)
         except yaml.YAMLError as exc:
             self._log_error(dash, name, "Error while parsing dashboard '{}':".format(dashfile))
             if hasattr(exc, 'problem_mark'):

--- a/appdaemon/plugins/dummy/dummyplugin.py
+++ b/appdaemon/plugins/dummy/dummyplugin.py
@@ -33,7 +33,7 @@ class DummyPlugin:
         with open(args["configuration"], 'r') as yamlfd:
             config_file_contents = yamlfd.read()
         try:
-            self.config = yaml.load(config_file_contents)
+            self.config = yaml.load(config_file_contents, Loader=yaml.SafeLoader)
         except yaml.YAMLError as exc:
             self.AD.log("WARNING", "Error loading configuration")
             if hasattr(exc, 'problem_mark'):


### PR DESCRIPTION
Use yaml.SafeLoader explicitly instead of the default loader.
Implement the `Loader=` parameter as per the [pyyaml wiki](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation).

See also #538