### PR TITLE
update appdaemon.yaml.example according to latest format

### DIFF
--- a/conf/appdaemon.yaml.example
+++ b/conf/appdaemon.yaml.example
@@ -1,12 +1,9 @@
-log:
-  logfile: STDOUT
-  errorfile: STDERR
 appdaemon:
-  threads: 10
   plugins:
     HASS:
       type: hass
       ha_url:
       token:
+http:
+  url:
 hadashboard:
-  dash_url:

--- a/dockerStart.sh
+++ b/dockerStart.sh
@@ -35,10 +35,10 @@ fi
 
 # if ENV DASH_URL is set, change the value in appdaemon.yaml
 if [ -n "$DASH_URL" ]; then
-  if grep -q "^  dash_url" $CONF/appdaemon.yaml; then
-    sed -i "s/^  dash_url:.*/  dash_url: $(echo $DASH_URL | sed -e 's/\\/\\\\/g; s/\//\\\//g; s/&/\\\&/g')/" $CONF/appdaemon.yaml
+  if grep -q "^  url" $CONF/appdaemon.yaml; then
+    sed -i "s/^  url:.*/  url: $(echo $DASH_URL | sed -e 's/\\/\\\\/g; s/\//\\\//g; s/&/\\\&/g')/" $CONF/appdaemon.yaml
   else
-    sed -i "s/# Apps/HADashboard:\r\n  dash_url: $(echo $DASH_URL | sed -e 's/\\/\\\\/g; s/\//\\\//g; s/&/\\\&/g')\r\n# Apps/" $CONF/appdaemon.yaml
+    sed -i "s/# Apps/HADashboard:\r\n  url: $(echo $DASH_URL | sed -e 's/\\/\\\\/g; s/\//\\\//g; s/&/\\\&/g')\r\n# Apps/" $CONF/appdaemon.yaml
   fi
 fi
 


### PR DESCRIPTION
The appdaemon.yaml format has changed but the `appdaemon.yaml.example` was not up-to-date.
This change should ensure new installations to have a validation configuration file.

`dockerStart.sh` has also been updated accordingly.

fixes #485 