### PR TITLE
update docs for Raspberry Pi Docker instructions

### DIFF
--- a/docs/INSTALL.rst
+++ b/docs/INSTALL.rst
@@ -209,32 +209,33 @@ Raspberry Pi Docker
 -------------------
 
 Since the official Docker image isn't compatible with raspberry Pi, you will need to build your own docker image
-from the downloaded repository. The Dockerfile also needs a couple of changes:
+from the downloaded repository.
 
-1. Change the image line to use a Resin image:
+.. code:: bash
 
-``FROM arm32v7/python:3.6``
+    $ git clone https://github.com/home-assistant/appdaemon.git
+    $ cd appdaemon
 
-2. Change the ``RUN`` line to the following:
+You must change the image line to use a Resin image in the Dockerfile:
 
-``RUN pip3 install requests && pip3 install .``
+``FROM arm32v7/python:3.6-alpine``
 
 You can then build and run a docker image locally as follows:
 
 .. code:: bash
-    $ git clone https://github.com/home-assistant/appdaemon.git
-    $ cd appdaemon
+
     $ docker build -t appdaemon .
-    $ docker run -t -i --name=appdaemon -p 5050:5050 \
-      -e HA_URL="<Your HA URL>" \
-      -e HA_KEY="<your HA Key>" \
-      -e DASH_URL="<Your DASH URL>" \
-      -v <Your AppDaemon conf dir>:/conf \
+    $ docker run --name=appdaemon -d -p 5050:5050 \
+      --restart=always \
+      -e HA_URL="<Your HA_URL value>" \
+      -e TOKEN="<your TOKEN value>" \
+      -e DASH_URL="http://$HOSTNAME:5050" \
+      -v <your_conf_folder>:/conf \
       appdaemon:latest
 
 For more information on running AppDaemon under Docker, see the Docker Tutorial. The key difference is that
 you will be running a locally built instance of AppDaemon rather than one from Docker Hub, so for run commands,
-make usre yo uspecify "appdaemon:latest" as the image, as above, rather than "acockburn/appdaemon:latest" as the tutorial states.
+make sure to specify "appdaemon:latest" as the image, as above, rather than "acockburn/appdaemon:latest" as the tutorial states.
 
 At the time of writing, @torkildr is maintaining a linked Raspberry Pi image here:
 

--- a/docs/INSTALL.rst
+++ b/docs/INSTALL.rst
@@ -216,11 +216,7 @@ from the downloaded repository.
     $ git clone https://github.com/home-assistant/appdaemon.git
     $ cd appdaemon
 
-You must change the image line to use a Resin image in the Dockerfile:
-
-``FROM arm32v7/python:3.6-alpine``
-
-You can then build and run a docker image locally as follows:
+You can then build and run the docker image locally as follows:
 
 .. code:: bash
 


### PR DESCRIPTION
I updated the **Raspberry Pi Docker** instructions on `docs/INSTALL.rst` since they were outdated. 

The most important change is to use `FROM arm32v7/python:3.6-alpine` instead of `FROM arm32v7/python:3.6` because the image has been changed to alpine in #486.