### PR TITLE
Do not load yaml files starting with dot

### DIFF
--- a/appdaemon/app_management.py
+++ b/appdaemon/app_management.py
@@ -188,7 +188,7 @@ class AppManagement:
                 subdirs[:] = [d for d in subdirs if d not in self.AD.exclude_dirs]
                 if root[-11:] != "__pycache__":
                     for file in files:
-                        if file[-5:] == ".yaml":
+                        if file[-5:] == ".yaml" and file[0] != ".":
                             self.logger.debug("Reading %s", os.path.join(root, file))
                             config = await utils.run_in_executor(self, self.read_config_file, os.path.join(root, file))
                             valid_apps = {}


### PR DESCRIPTION
Some operating systems or editors create backup or cache files when editing a file. Usually, these files are saved to filenames starting with ``.`` (dot). Appdaemon loads everything that ends in ".yaml", even if the file name starts with a dot. This creates the following issue (given that ``._apps.yaml`` is in a binary format):

```
2019-05-07 21:30:46.227068 WARNING AppDaemon: ------------------------------------------------------------
2019-05-07 21:30:46.227594 WARNING AppDaemon: Unexpected error loading config file: /conf/apps/._apps.yaml
2019-05-07 21:30:46.228201 WARNING AppDaemon: ------------------------------------------------------------
2019-05-07 21:30:46.234606 WARNING AppDaemon: Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/appdaemon/appdaemon.py", line 1677, in read_config_file
    config_file_contents = yamlfd.read()
  File "/usr/local/lib/python3.6/codecs.py", line 321, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb0 in position 37: invalid start byte
```

Searching for this issue it turns out that many people run into it and are misled into thinking something is wrong in their yaml file -- see [here](https://community.home-assistant.io/t/warnings-in-log/46616), [here](https://community.home-assistant.io/t/new-release-foscam-v3-app-updated-for-appdaemon-3-0-beta/44025/3) or [here](https://community.home-assistant.io/t/trying-to-get-started-ad-up-and-running/45846/3).

This PR skips loading yaml files starting with ``.``.