### PR TITLE
Fix for listen_log callback

### DIFF
--- a/appdaemon/threading.py
+++ b/appdaemon/threading.py
@@ -589,7 +589,7 @@ class Threading:
                         if args["event"] == "__AD_LOG_EVENT":
                             if self.validate_callback_sig(name, "log_event", funcref):
                                 utils.run_coroutine_threadsafe(self, self.update_thread_info(thread_id, callback, name, _type, _id))
-                                funcref(data["app_name"], data["ts"], data["level"], data["type"], data["message"], args["kwargs"])
+                                funcref(data["app_name"], data["ts"], data["level"], data["log_type"], data["message"], args["kwargs"])
                         else:
                             if self.validate_callback_sig(name, "event", funcref):
                                 utils.run_coroutine_threadsafe(self, self.update_thread_info(thread_id, callback, name, _type, _id))

--- a/appdaemon/threading.py
+++ b/appdaemon/threading.py
@@ -626,7 +626,7 @@ class Threading:
 
         if type in callback_args:
             if len(sig.parameters) != callback_args[type]["count"]:
-                self.logger.warning("Incorrect signature type for callback %s(), should be %s - discarding", funcref.__name__, callback_args[type]["signature"])
+                self.logger.warning("Incorrect signature type for callback %s() in %s, should be %s - discarding", funcref.__name__, name, callback_args[type]["signature"])
                 return False
             else:
                 return True


### PR DESCRIPTION
This fixes an issue, whereby the `listen_log` `log_type` flag didn't report the right log

Added app name to wrong callback signature warning. So
```
2019-05-12 12:15:22.465483 WARNING AppDaemon: Incorrect signature type for callback get_ha_status_update_cf(), should be f(self, event, data, kwargs) - discarding
```
Can be 

```
2019-05-12 16:00:56.181798 WARNING AppDaemon: Incorrect signature type for callback get_ha_status_update_cf() in odianosen_iphone_cf_list, should be f(self, event, data, kwargs) - discarding
```
Which makes more sense and easier to debug