### PR TITLE
Modified `immediate` Flag in Listen_state

### DIFF
--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -514,6 +514,7 @@ class ADAPI:
 
     def cancel_timer(self, handle):
         name = self.name
+        self.logger.debug("Canceling timer with handle %s for %s", handle, self.name)
         utils.run_coroutine_threadsafe(self, self.AD.sched.cancel_timer(name, handle))
 
     def info_timer(self, handle):

--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -352,6 +352,8 @@ class ADAPI:
         name = self.name
         if entity is not None and "." in entity:
             self._check_entity(namespace, entity)
+        
+        self.logger.debug("Calling listen_state for %s", self.name)
         return utils.run_coroutine_threadsafe(self, self.AD.state.add_state_callback(name, namespace, entity, cb, kwargs))
 
     def cancel_listen_state(self, handle):

--- a/appdaemon/state.py
+++ b/appdaemon/state.py
@@ -114,7 +114,7 @@ class State:
                         else:
                             run = False
                     else: #use the present state of the entity
-                        if __attribute == None:
+                        if __attribute == None and "state" in self.state[namespace][entity]:
                             __new_state = self.state[namespace][entity]["state"]
                         elif __attribute != None and __attribute in self.state[namespace][entity]["attributes"]:
                             __new_state = self.state[namespace][entity]["attributes"][__attribute]

--- a/appdaemon/state.py
+++ b/appdaemon/state.py
@@ -112,7 +112,7 @@ class State:
                             run = False
                     else: #use the present state of the entity
                         if __attribute == None:
-                            __new_state = self.state[namespace][entity]["state"] == kwargs["new"]
+                            __new_state = self.state[namespace][entity]["state"]
                         elif __attribute != None and __attribute in self.state[namespace][entity]["attributes"]:
                             __new_state = self.state[namespace][entity]["attributes"][__attribute]
                     if "duration" in kwargs:

--- a/appdaemon/state.py
+++ b/appdaemon/state.py
@@ -100,32 +100,23 @@ class State:
                 __new_state = None
                 __attribute = None
                 run = True
-
                 if entity is not None:
-                    
                     if "attribute" in kwargs:
                         __attribute = kwargs["attribute"]
-
                     if "new" in kwargs:
                         if __attribute == None and self.state[namespace][entity]["state"] == kwargs["new"]:
                             __new_state = kwargs["new"]
-                            
                         elif __attribute != None and __attribute in self.state[namespace][entity]["attributes"] and self.state[namespace][entity]["attributes"][__attribute] == kwargs["new"]:
                             __new_state = kwargs["new"]
-
                         else:
                             run = False
-                    
                     else: #use the present state of the entity
                         if __attribute == None:
                             __new_state = self.state[namespace][entity]["state"] == kwargs["new"]
-
                         elif __attribute != None and __attribute in self.state[namespace][entity]["attributes"]:
                             __new_state = self.state[namespace][entity]["attributes"][__attribute]
-
                     if "duration" in kwargs:
                         __duration = kwargs["duration"]
-
                 if run:
                     exec_time = await self.AD.sched.get_now() + datetime.timedelta(seconds=int(__duration))
                     kwargs["__duration"] = await self.AD.sched.insert_schedule(
@@ -136,7 +127,6 @@ class State:
                         __new_state=__new_state, **kwargs
                     )
                     
-
             await self.AD.state.add_entity("admin", "state_callback.{}".format(handle), "active",
                                                     {"app": name, "listened_entity": entity, "function": cb.__name__,
                                                      "pinned": pin_app, "pinned_thread": pin_thread, "fired": 0, "executed":0, "kwargs": kwargs})
@@ -471,4 +461,4 @@ class State:
             "__entity", "__duration", "__old_state", "__new_state",
             "oneshot", "pin_app", "pin_thread", "__delay"
         ] + app.list_constraints())
-   
+  

--- a/appdaemon/state.py
+++ b/appdaemon/state.py
@@ -99,8 +99,11 @@ class State:
                 __duration = 0 # run it immediately
                 __new_state = None
                 __attribute = None
-                run = True
-                if entity is not None:
+                run = False
+                
+                if entity is not None and entity in self.state[namespace]:
+                    run = True
+                    
                     if "attribute" in kwargs:
                         __attribute = kwargs["attribute"]
                     if "new" in kwargs:

--- a/appdaemon/state.py
+++ b/appdaemon/state.py
@@ -96,16 +96,46 @@ class State:
             # start the clock immediately if the device is already in the new state
             #
             if "immediate" in kwargs and kwargs["immediate"] is True:
-                if entity is not None and "new" in kwargs and "duration" in kwargs:
-                    if self.state[namespace][entity]["state"] == kwargs["new"]:
-                        exec_time = await self.AD.sched.get_now() + datetime.timedelta(seconds=int(kwargs["duration"]))
-                        kwargs["__duration"] = await self.AD.sched.insert_schedule(
-                            name, exec_time, cb, False, None,
-                            __entity=entity,
-                            __attribute=None,
-                            __old_state=None,
-                            __new_state=kwargs["new"], **kwargs
-                        )
+                __duration = 0 # run it immediately
+                __new_state = None
+                __attribute = None
+                run = True
+
+                if entity is not None:
+                    
+                    if "attribute" in kwargs:
+                        __attribute = kwargs["attribute"]
+
+                    if "new" in kwargs:
+                        if __attribute == None and self.state[namespace][entity]["state"] == kwargs["new"]:
+                            __new_state = kwargs["new"]
+                            
+                        elif __attribute != None and __attribute in self.state[namespace][entity]["attributes"] and self.state[namespace][entity]["attributes"][__attribute] == kwargs["new"]:
+                            __new_state = kwargs["new"]
+
+                        else:
+                            run = False
+                    
+                    else: #use the present state of the entity
+                        if __attribute == None:
+                            __new_state = self.state[namespace][entity]["state"] == kwargs["new"]
+
+                        elif __attribute != None and __attribute in self.state[namespace][entity]["attributes"]:
+                            __new_state = self.state[namespace][entity]["attributes"][__attribute]
+
+                    if "duration" in kwargs:
+                        __duration = kwargs["duration"]
+
+                if run:
+                    exec_time = await self.AD.sched.get_now() + datetime.timedelta(seconds=int(__duration))
+                    kwargs["__duration"] = await self.AD.sched.insert_schedule(
+                        name, exec_time, cb, False, None,
+                        __entity=entity,
+                        __attribute=__attribute,
+                        __old_state=None,
+                        __new_state=__new_state, **kwargs
+                    )
+                    
 
             await self.AD.state.add_entity("admin", "state_callback.{}".format(handle), "active",
                                                     {"app": name, "listened_entity": entity, "function": cb.__name__,
@@ -441,4 +471,4 @@ class State:
             "__entity", "__duration", "__old_state", "__new_state",
             "oneshot", "pin_app", "pin_thread", "__delay"
         ] + app.list_constraints())
-    
+   

--- a/docs/AD_API_REFERENCE.rst
+++ b/docs/AD_API_REFERENCE.rst
@@ -292,13 +292,16 @@ immediate = (optional)
 
 True or False
 
-Quick check enables the countdown for a ``delay`` parameter to start at the time
-the callback is registered, rather than requiring one or more state changes. This can be useful if
-for instance you want the duration to be triggered immediately if a light is already on.
+Quick check enables the countdown for a ``delay`` parameter to start at the time, if given.
+If the ``duration`` paremter is not gien, the callback is ran immediately. What this means is that
+the callback is registered, rather than requiring one or more state changes, and ran also. This can be useful if
+for instance you want the callback to be triggered immediately if a light is already on, or after a ``duration`` if given.
 
 If ``immediate`` is in use, and ``new`` and ``duration`` are both set, AppDaemon will check if the entity
-is already set to the new state and if so it will start the clock immediately. In this case, old will be ignored
-and when the timer triggers, its state will be set to None. If new or entity are not set, ``immediate`` will be ignored.
+is already set to the new state and if so it will start the clock immediately. If ``new`` and ``duration``is not set, 
+``immediate`` will trigger the callback immediately and report in its callback the ``new`` parameter as the present
+state of the entity. if ``attribute`` is specified, the state of the ``attribute`` will be used instead of ``state``.
+In these cases, old will be ignored and when the callback is triggered, its state will be set to None.
 
 oneshot = (optional)
 ''''''''''''''''''''

--- a/docs/AD_API_REFERENCE.rst
+++ b/docs/AD_API_REFERENCE.rst
@@ -293,7 +293,7 @@ immediate = (optional)
 True or False
 
 Quick check enables the countdown for a ``delay`` parameter to start at the time, if given.
-If the ``duration`` paremter is not given, the callback is ran immediately. What this means is that
+If the ``duration`` parameter is not given, the callback is ran immediately. What this means is that
 after the callback is registered, rather than requiring one or more state changes before it is ran, it immediately checks
 the entity's states based on given parameters. If the conditions are right, the callback is ran immediately at the time 
 of registering. This can be useful, if for instance you want the callback to be triggered immediately if a light is already on, or after a ``duration`` if given.

--- a/docs/AD_API_REFERENCE.rst
+++ b/docs/AD_API_REFERENCE.rst
@@ -293,9 +293,10 @@ immediate = (optional)
 True or False
 
 Quick check enables the countdown for a ``delay`` parameter to start at the time, if given.
-If the ``duration`` paremter is not gien, the callback is ran immediately. What this means is that
-the callback is registered, rather than requiring one or more state changes, and ran also. This can be useful if
-for instance you want the callback to be triggered immediately if a light is already on, or after a ``duration`` if given.
+If the ``duration`` paremter is not given, the callback is ran immediately. What this means is that
+after the callback is registered, rather than requiring one or more state changes before it is ran, it immediately checks
+the entity's states based on given parameters. If the conditions are right, the callback is ran immediately at the time 
+of registering. This can be useful, if for instance you want the callback to be triggered immediately if a light is already on, or after a ``duration`` if given.
 
 If ``immediate`` is in use, and ``new`` and ``duration`` are both set, AppDaemon will check if the entity
 is already set to the new state and if so it will start the clock immediately. If ``new`` and ``duration``is not set, 

--- a/docs/AD_API_REFERENCE.rst
+++ b/docs/AD_API_REFERENCE.rst
@@ -299,10 +299,10 @@ the entity's states based on given parameters. If the conditions are right, the 
 of registering. This can be useful, if for instance you want the callback to be triggered immediately if a light is already on, or after a ``duration`` if given.
 
 If ``immediate`` is in use, and ``new`` and ``duration`` are both set, AppDaemon will check if the entity
-is already set to the new state and if so it will start the clock immediately. If ``new`` and ``duration``is not set, 
+is already set to the new state and if so it will start the clock immediately. If ``new`` and ``duration``are not set, 
 ``immediate`` will trigger the callback immediately and report in its callback the ``new`` parameter as the present
 state of the entity. if ``attribute`` is specified, the state of the ``attribute`` will be used instead of ``state``.
-In these cases, old will be ignored and when the callback is triggered, its state will be set to None.
+In these cases, old will be ignored and when the callback is triggered, its state will be set to ``None``.
 
 oneshot = (optional)
 ''''''''''''''''''''

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -25,6 +25,8 @@ Change Log
 - Added ``parse_datetime()``
 - ``run_once()``, ``run_at()`` and ``run_daily()`` now optionally take ``parse_time()`` or ``parse_datetime()`` style arguments for specifying time
 - Refactored appdaemon.py for greater readability and easier maintenance
+- Expanded on the ability to trigger callbacks immediately using the ``immediate`` flag, without need of specifing the ``new`` nor ``duration`` parameter
+- Allowed to make use of ``attribute`` when using the ``immediate`` flag
 - Added initial version of the Admin Interface
 - Added User Defined Namespaces
 - Rewrote logging to include user defined logs and formats

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -25,8 +25,8 @@ Change Log
 - Added ``parse_datetime()``
 - ``run_once()``, ``run_at()`` and ``run_daily()`` now optionally take ``parse_time()`` or ``parse_datetime()`` style arguments for specifying time
 - Refactored appdaemon.py for greater readability and easier maintenance
-- Expanded on the ability to trigger callbacks immediately using the ``immediate`` flag, without need of specifing the ``new`` nor ``duration`` parameter
-- Allowed to make use of ``attribute`` when using the ``immediate`` flag
+- Expanded on the ability to trigger ``listen_state`` callbacks immediately using the ``immediate`` flag, without need of specifing the ``new`` nor ``duration`` parameter.
+- Allowed to make use of ``attribute`` when using the ``immediate`` flag in ``listen_state``
 - Added initial version of the Admin Interface
 - Added User Defined Namespaces
 - Rewrote logging to include user defined logs and formats


### PR DESCRIPTION
Expanded on the ability to allow for when listening to state changes, the callback function can be ran immediately to allow for the function to be ran at startup.

The following are possible:
- If `duration` is not specified, the callback is ran immediately. If specified, it will be ran after the specified `duration`
- If `new` is specified, it will only run the callback, if the present `state` is the `new` state

Regards