### PR TITLE
Fix incorrect name of event fire on disconnect in docs

### DIFF
--- a/docs/APPGUIDE.rst
+++ b/docs/APPGUIDE.rst
@@ -1421,7 +1421,7 @@ has been running connected to Home Assistant for a while and the
 connection is unexpectedly lost, the following will occur:
 
 -  When HASS first goes down or becomes disconnected, an event called
-   ``plugin_disconnected`` will fire
+   ``plugin_stopped`` will fire
 -  While disconnected from HASS, Apps will continue to run
 -  Schedules will continue to be honored
 -  Any operation reading locally cached state will succeed


### PR DESCRIPTION
Fix the name of the event that gets fired by AD when plugin gets disconnected - the actual name of the event is "plugin_stopped" as defined https://github.com/home-assistant/appdaemon/blob/fbdd4f1242076d849b6d764dd82e362ffb729641/appdaemon/plugin_management.py#L185