### PR TITLE
Constraint days move

### DIFF
--- a/appdaemon/plugins/hass/hassapi.py
+++ b/appdaemon/plugins/hass/hassapi.py
@@ -49,7 +49,6 @@ class Hass(adbase.ADBase, adapi.ADAPI):
         self.register_constraint("constrain_presence")
         self.register_constraint("constrain_input_boolean")
         self.register_constraint("constrain_input_select")
-        self.register_constraint("constrain_days")
 
     #
     # Device Trackers
@@ -133,13 +132,6 @@ class Hass(adbase.ADBase, adapi.ADAPI):
             unconstrained = False
 
         return unconstrained
-
-    def constrain_days(self, value):
-        day = self.get_now().weekday()
-        daylist = [utils.day_of_week(day) for day in value.split(",")]
-        if day in daylist:
-            return True
-        return False
 
     #
     # Helper functions for services

--- a/appdaemon/threading.py
+++ b/appdaemon/threading.py
@@ -440,6 +440,20 @@ class Threading:
 
         return unconstrained
 
+    async def check_days_constraint(self, args, name):
+        unconstrained = True
+        if "constrain_days" in args:
+            days = args["constrain_days"]
+            now = await self.AD.sched.get_now()
+            daylist = []
+            for day in days.split(","):
+                daylist.append(await utils.run_in_executor(self, utils.day_of_week, day))
+
+            if now.weekday() not in daylist:
+                unconstrained = False
+
+        return unconstrained
+
     #
     # Workers
     #
@@ -529,6 +543,9 @@ class Threading:
                 unconstrained = False
         if not await self.check_time_constraint(self.AD.app_management.app_config[name], name):
             unconstrained = False
+        elif not await self.check_days_constraint(self.AD.app_management.app_config[name], name):
+            unconstrained = False
+
         #
         # Callback level constraints
         #
@@ -539,6 +556,8 @@ class Threading:
                 if not constrained:
                     unconstrained = False
             if not await self.check_time_constraint(myargs["kwargs"], name):
+                unconstrained = False
+            elif not await self.check_days_constraint(self.AD.app_management.app_config[name], name):
                 unconstrained = False
 
         if unconstrained:
@@ -635,4 +654,3 @@ class Threading:
             self.logger.error("Unknown callback type: %s", type)
 
         return False
-

--- a/appdaemon/threading.py
+++ b/appdaemon/threading.py
@@ -557,7 +557,7 @@ class Threading:
                     unconstrained = False
             if not await self.check_time_constraint(myargs["kwargs"], name):
                 unconstrained = False
-            elif not await self.check_days_constraint(self.AD.app_management.app_config[name], name):
+            elif not await self.check_days_constraint(myargs["kwargs"], name):
                 unconstrained = False
 
         if unconstrained:

--- a/docs/APPGUIDE.rst
+++ b/docs/APPGUIDE.rst
@@ -590,6 +590,16 @@ times that span midnight.
     constrain_start_time: sunset - 00:45:00
     constrain_end_time: sunrise + 00:45:00
 
+days
+^^^^
+
+The day constraint consists of as list of days for which the callbacks
+will fire, e.g.
+
+.. code:: yaml
+
+    constrain_days: mon,tue,wed
+
 Other constraints may be supplied by the plugin in use.
 
 HASS Plugin Constraints
@@ -661,20 +671,9 @@ trackers. It takes 3 possible values:
     constrain_presence: someone
     # or
     constrain_presence: noone
-
-days
-^^^^
-
-The day constraint consists of as list of days for which the callbacks
-will fire, e.g.
-
-.. code:: yaml
-
-    constrain_days: mon,tue,wed
-
+    
 Callback constraints can also be applied to individual callbacks within
 Apps, see later for more details.
-
 
 AppDaemon and Threading
 -----------------------
@@ -2339,14 +2338,12 @@ We start off with a python function that accepts a value to be evaluated like th
         else:
             return False
 
-
 To use this in a callback level constraint simply use:
 
 .. code:: python
 
         self.register_constraint("is_daylight")
         handle = self.run_every(self.callback, time, 1, is_daylight=1)
-
 
 Now ``callback()`` will only fire if the sun is up.
 

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -19,6 +19,7 @@ Change Log
 - Added the ``run_in_thread()`` api call - with assistance from `Odianosen Ejale <https://github.com/Odianosen25>`__
 - reworked log listening functions to be more robust and added the ability to have multiple callbacks per app
 - Refactored plugin APIs to remove duplication
+- Moved `contrain_days` from being Hass only to all app, regardless of plugin used
 - Added checking for overdue threads
 - Added error checking for callback signatures
 - Added app attributes that allows to access AD's ``config`` and ``apps`` directories within apps 


### PR DESCRIPTION
Moved `contrain_days` from being only a `Hass` based constraint, to allow to be used across all apps, even if running `adbase` style of coding