### PR TITLE
Oneshot duration fix

### DIFF
--- a/appdaemon/scheduler.py
+++ b/appdaemon/scheduler.py
@@ -89,7 +89,7 @@ class Scheduler:
                 return
             # Call function
             if "__entity" in args["kwargs"]:
-                await self.AD.threading.dispatch_worker(name, {
+                executed = await self.AD.threading.dispatch_worker(name, {
                     "id": uuid_,
                     "name": name,
                     "objectid": self.AD.app_management.objects[name]["id"],
@@ -103,6 +103,11 @@ class Scheduler:
                     "pin_thread": args["pin_thread"],
                     "kwargs": args["kwargs"],
                 })
+
+                if executed is True:
+                    remove = args["kwargs"].get("oneshot", False)
+                    if remove is True:
+                        await self.AD.state.cancel_state_callback(args["kwargs"]["__handle"], name)
             else:
                 await self.AD.threading.dispatch_worker(name, {
                     "id": uuid_,

--- a/appdaemon/state.py
+++ b/appdaemon/state.py
@@ -127,6 +127,10 @@ class State:
                         __duration = kwargs["duration"]
                 if run:
                     exec_time = await self.AD.sched.get_now() + datetime.timedelta(seconds=int(__duration))
+
+                    if kwargs.get("oneshot", False):
+                        kwargs["__handle"] = handle
+
                     kwargs["__duration"] = await self.AD.sched.insert_schedule(
                         name, exec_time, cb, False, None,
                         __entity=entity,

--- a/appdaemon/threading.py
+++ b/appdaemon/threading.py
@@ -487,6 +487,11 @@ class Threading:
                 if "duration" in kwargs:
                     # Set a timer
                     exec_time = await self.AD.sched.get_now() + timedelta(seconds=int(kwargs["duration"]))
+
+                    #check if it is a oneshot and store handle
+                    if kwargs.get("oneshot", False):
+                        kwargs["__handle"] = uuid_
+
                     kwargs["__duration"] = await self.AD.sched.insert_schedule(
                         name, exec_time, funcref, False, None,
                         __entity=entity,
@@ -635,4 +640,3 @@ class Threading:
             self.logger.error("Unknown callback type: %s", type)
 
         return False
-


### PR DESCRIPTION
This is a fix for an issue whereby when `duration` is used alongside `oneshot`, the callback is not automatically cancelled. This leads to the callback being executed continuously. 