### PR TITLE
keep build-dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,7 @@ RUN pip3 install --no-cache-dir python-dateutil
 
 # Install dependencies
 RUN apk add --no-cache --virtual build-dependencies gcc libffi-dev musl-dev \
-    && pip3 install --no-cache-dir . \
-    && apk del build-dependencies
+    && pip3 install --no-cache-dir .
 
 # Install additional packages
 RUN apk add --no-cache curl


### PR DESCRIPTION
without build-dependencies, the auto run of requirements.txt fails when a library needs gcc to build (numpy, for example). 

