### PR TITLE
Add Support for rendering HASS templates

### DIFF
--- a/appdaemon/plugins/hass/hassapi.py
+++ b/appdaemon/plugins/hass/hassapi.py
@@ -1,4 +1,5 @@
 import requests
+from ast import literal_eval
 
 import appdaemon.adbase as adbase
 import appdaemon.adapi as adapi
@@ -279,3 +280,20 @@ class Hass(adbase.ADBase, adapi.ADAPI):
 
         result = self.call_service("database/history", **rargs)
         return result
+
+    @hass_check
+    def render_template(self, template, **kwargs):
+        namespace = self._get_namespace(**kwargs)
+
+        if "namespace" in kwargs:
+            del kwargs["namespace"]
+
+        rargs = kwargs
+        rargs["namespace"] = namespace
+        rargs["template"] = template
+
+        result = self.call_service("template/render", **rargs)
+        try:
+            return literal_eval(result)
+        except (SyntaxError, ValueError):
+            return result

--- a/appdaemon/plugins/hass/hassapi.py
+++ b/appdaemon/plugins/hass/hassapi.py
@@ -283,6 +283,28 @@ class Hass(adbase.ADBase, adapi.ADAPI):
 
     @hass_check
     def render_template(self, template, **kwargs):
+        """Renders a Home Assistant Template
+
+        Args:
+            template (str): The Home Assistant Template to be rendered.
+
+        Keyword Args:
+            None.
+
+        Returns:
+            The rendered template in a native Python type.
+
+        Examples:
+            >>> self.render_template("{{ states('sun.sun') }}")
+            Returns (str) above_horizon
+
+            >>> self.render_template("{{ is_state('sun.sun', 'above_horizon') }}")
+            Returns (bool) True
+
+            >>> self.render_template("{{ states('sensor.outside_temp') }}")
+            Returns (float) 97.2
+
+        """
         namespace = self._get_namespace(**kwargs)
 
         if "namespace" in kwargs:

--- a/appdaemon/plugins/hass/hassplugin.py
+++ b/appdaemon/plugins/hass/hassplugin.py
@@ -453,8 +453,12 @@ class HassPlugin(PluginBase):
 
             apiurl = "{}/api/history/period{}{}{}".format(config["ha_url"], timeStamp, filter_entity_id, eTime)
 
+        elif domain == "template":
+            apiurl = "{}/api/template".format(config["ha_url"])
+            
         else:
             apiurl = "{}/api/services/{}/{}".format(config["ha_url"], domain, service)
+
         try:
             if domain == "database":
                 r = await self.session.get(apiurl, headers=headers, verify_ssl=self.cert_verify)
@@ -462,7 +466,10 @@ class HassPlugin(PluginBase):
                 r = await self.session.post(apiurl, headers=headers, json=data, verify_ssl=self.cert_verify)
                 
             if r.status == 200 or r.status == 201:
-                result = await r.json()
+                if domain == "template":
+                    result = await r.text()
+                else:
+                    result = await r.json()
             else:
                 self.logger.warning("Error calling Home Assistant service %s/%s/%s", namespace, domain, service)
                 txt = await r.text()
@@ -570,6 +577,7 @@ class HassPlugin(PluginBase):
             r.raise_for_status()
             services = await r.json()
             services.append({"domain": "database","services": ["history"]}) #manually added HASS history service
+            services.append({"domain": "template","services": ["render"]})
 
             return services
         except:


### PR DESCRIPTION
This provides self.render_template(template="some hass template here").

To be used like this:
```python
import appdaemon.plugins.hass.hassapi as hass


class Test(hass.Hass):

    def initialize(self):
        ret = self.render_template("{{ states('sensor.house_mean_temp') }}")
        self.log("FLOAT {}: {}".format(type(ret), ret))

        ret = self.render_template("{{ states('binary_sensor.office_occupied') }}")
        self.log("STRING {}: {}".format(type(ret), ret))

        ret = self.render_template("{{ is_state('binary_sensor.office_occupied', 'on') }}")
        self.log("BOOL {}: {}".format(type(ret), ret))
```
