### PR TITLE
MQTT fixes

### DIFF
--- a/appdaemon/plugins/mqtt/mqttplugin.py
+++ b/appdaemon/plugins/mqtt/mqttplugin.py
@@ -293,8 +293,6 @@ class MqttPlugin(PluginBase):
             self.logger.warning('Topic not provided for Service Call {!r}.'.format(service))
             raise ValueError("Topic not provided, please provide Topic for Service Call")
 
-        return result
-
     async def process_mqtt_wildcard(self, wildcard):
         if wildcard.rstrip('#') not in self.mqtt_wildcards:
             self.mqtt_wildcards.append(wildcard.rstrip('#'))

--- a/appdaemon/plugins/mqtt/mqttplugin.py
+++ b/appdaemon/plugins/mqtt/mqttplugin.py
@@ -247,6 +247,8 @@ class MqttPlugin(PluginBase):
 
                     if result[0] == 0:
                         self.logger.debug("Publishing Payload %s to Topic %s Successful", payload, topic)
+                    else:
+                        self.logger.warning("Publishing Payload %s to Topic %s was not Successful", payload, topic)
 
                 elif service == 'subscribe':
                     self.logger.debug("Subscribe to Topic: %s", topic)
@@ -270,6 +272,8 @@ class MqttPlugin(PluginBase):
                         self.logger.debug("Unsubscription from Topic %s Successful", topic)
                         if topic in self.mqtt_client_topics:
                             self.mqtt_client_topics.remove(topic)
+                    else:
+                        self.logger.warning("Unsubscription from Topic %s was not Sucessful", topic)
 
                 else:
                     self.logger.warning("Wrong Service Call %s for MQTT", service)

--- a/appdaemon/plugins/mqtt/mqttplugin.py
+++ b/appdaemon/plugins/mqtt/mqttplugin.py
@@ -230,6 +230,7 @@ class MqttPlugin(PluginBase):
 
     async def call_plugin_service(self, namespace, domain, service, kwargs):
 
+        result = None
         if 'topic' in kwargs:
             if not self.mqtt_connected:  # ensure mqtt plugin is connected
                 self.logger.warning("Attempt to call Mqtt Service while disconnected: %s", service)
@@ -292,6 +293,8 @@ class MqttPlugin(PluginBase):
         else:
             self.logger.warning('Topic not provided for Service Call {!r}.'.format(service))
             raise ValueError("Topic not provided, please provide Topic for Service Call")
+
+        return result
 
     async def process_mqtt_wildcard(self, wildcard):
         if wildcard.rstrip('#') not in self.mqtt_wildcards:

--- a/appdaemon/plugins/mqtt/mqttplugin.py
+++ b/appdaemon/plugins/mqtt/mqttplugin.py
@@ -257,10 +257,10 @@ class MqttPlugin(PluginBase):
                         result = await utils.run_in_executor(self, self.mqtt_client.subscribe, topic, qos)
 
                         if result[0] == 0:
-                            self.logger.debug("Subscription to Topic %s Sucessful", topic)
+                            self.logger.debug("Subscription to Topic %s Successful", topic)
                             self.mqtt_client_topics.append(topic)
                         else:
-                            self.logger.warning("Subscription to Topic %s was not Sucessful", topic)
+                            self.logger.warning("Subscription to Topic %s was not Successful", topic)
                     else:
                         self.logger.info("Topic %s already subscribed to", topic)
 

--- a/appdaemon/plugins/mqtt/mqttplugin.py
+++ b/appdaemon/plugins/mqtt/mqttplugin.py
@@ -215,7 +215,7 @@ class MqttPlugin(PluginBase):
             topic = msg.topic
 
             if self.mqtt_wildcards != [] and list(filter(lambda x: x in topic, self.mqtt_wildcards)) != []: #check if any of the wildcards belong
-                wildcard = list(filter(lambda x: x in topic, self.mqtt_wildcards))[0] + '#'
+                wildcard = list(filter(lambda x: topic.startswith(x), self.mqtt_wildcards))[0] + '#'
 
                 data = {'event_type': self.mqtt_event_name, 'data': {'topic': topic, 'payload': msg.payload.decode(), 'wildcard': wildcard}}
 


### PR DESCRIPTION
Two fixes:

1) wildcard topics were matching anywhere in the topic. However, they should only match from the beginning of the topic.  Example:

A Wildcard of `test/#` should match:
test/a
test/b
test/a/b/c/d/e/f
test/test
test/test/a

but it should not match:
a/test
a/test/b
a/b/c/test/d

2) the last line of call_plugin_service() was `return result`. However, in situations like subscribing to a topic that was already subscribed to, no result was generated which led to an error:
```
WARNING AppDaemon: Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/appdaemon/services.py", line 60, in call_service
    return await funcref(ns, domain, service, data)
  File "/usr/local/lib/python3.7/site-packages/appdaemon/plugins/mqtt/mqttplugin.py", line 292, in call_plugin_service
    return result
UnboundLocalError: local variable 'result' referenced before assignment
```

I didn't see any place where `result` was actually being used, so I removed it entirely. 