### PR TITLE
global_modules feature and fix

### DIFF
--- a/appdaemon/app_management.py
+++ b/appdaemon/app_management.py
@@ -272,11 +272,13 @@ class AppManagement:
                                 for app in config:
                                     if config[app] is not None:
                                         if app == "global_modules":
-                                            if isinstance(config[app], list):
+                                            if isinstance(config[app], str):
+                                                valid_apps[app] = [config[app]]
+                                            elif isinstance(config[app], list):
                                                 valid_apps[app] = config[app]
                                             else:
                                                 if self.AD.invalid_yaml_warnings:
-                                                    self.logger.warning("global_modules should be a list in File '%s' - ignoring", file)
+                                                    self.logger.warning("global_modules should be a list or a string in File '%s' - ignoring", file)
  
                                         elif "class" in config[app] and "module" in config[app]:
                                             valid_apps[app] = config[app]

--- a/appdaemon/app_management.py
+++ b/appdaemon/app_management.py
@@ -272,7 +272,12 @@ class AppManagement:
                                 for app in config:
                                     if config[app] is not None:
                                         if app == "global_modules":
-                                            valid_apps[app] = config[app]
+                                            if isinstance(config[app], list):
+                                                valid_apps[app] = config[app]
+                                            else:
+                                                if self.AD.invalid_yaml_warnings:
+                                                    self.logger.warning("global_modules should be a list in File '%s' - ignoring", file)
+ 
                                         elif "class" in config[app] and "module" in config[app]:
                                             valid_apps[app] = config[app]
                                         else:

--- a/appdaemon/app_management.py
+++ b/appdaemon/app_management.py
@@ -290,6 +290,11 @@ class AppManagement:
                             if new_config is None:
                                 new_config = {}
                             for app in valid_apps:
+                                if app == "global_modules":
+                                    if app in new_config:
+                                        new_config[app].extend(valid_apps[app])
+                                        continue
+
                                 if app in new_config:
                                     self.logger.warning("File '%s' duplicate app: %s - ignoring", os.path.join(root, file), app)
                                 else:

--- a/appdaemon/app_management.py
+++ b/appdaemon/app_management.py
@@ -402,6 +402,9 @@ class AppManagement:
                 # Check for changes
 
                 for name in self.app_config:
+                    if name == "global_modules":
+                        continue
+
                     if name in new_config:
                         if self.app_config[name] != new_config[name]:
                             # Something changed, clear and reload
@@ -424,6 +427,9 @@ class AppManagement:
                         await self.remove_entity(name)
 
                 for name in new_config:
+                    if name == "global_modules":
+                        continue
+
                     if name not in self.app_config:
                         #
                         # New section added!


### PR DESCRIPTION
Features:
This allows global_modules to exist in more than one yaml file. Configuration is merged.

Breaking Change(?):
global_modules must be a list. Warning generated if it isn't.

Bug Fixes:
AppDaemon no longer generates the following error after changing global_modules while running:
```
2019-08-16 12:15:46.008372 INFO AppDaemon: Terminating global_modules
2019-08-16 12:15:46.008994 WARNING global_modules: ------------------------------------------------------------
2019-08-16 12:15:46.009184 WARNING global_modules: Unexpected error initializing app: global_modules:
2019-08-16 12:15:46.009354 WARNING global_modules: ------------------------------------------------------------
2019-08-16 12:15:46.009914 WARNING global_modules: Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/appdaemon/app_management.py", line 752, in check_app_updates
    await self.init_object(app)
  File "/usr/local/lib/python3.7/site-packages/appdaemon/app_management.py", line 222, in init_object
    self.logger.info("Initializing app %s using class %s from module %s", name, app_args["class"], app_args["module"])
TypeError: list indices must be integers or slices, not str
appdaemon-dev      |
2019-08-16 12:15:46.010092 WARNING global_modules: ------------------------------------------------------------
2019-08-16 12:15:46.010860 WARNING AppDaemon: Unable to find module global_modules - initialize() skipped
```