### PR TITLE
allow injecting arbitrary headers

### DIFF
--- a/appdaemon/http.py
+++ b/appdaemon/http.py
@@ -143,6 +143,9 @@ class HTTP:
 
             self.app = web.Application()
 
+            if "headers" in self.http:
+                self.app.on_response_prepare.append(self.add_response_headers)
+
             # Setup event stream
 
             self.stream = stream.ADStream(self.AD, self.app, self.transport, self.on_connect, self.on_message)
@@ -286,6 +289,10 @@ class HTTP:
             self.logger.warning('-' * 60)
             self.logger.warning(traceback.format_exc())
             self.logger.warning('-' * 60)
+
+    async def add_response_headers(self, request, response):
+        for header, value in self.http['headers'].items():
+            response.headers[header] = value
 
     def stop(self):
         self.stopping = True

--- a/docs/CONFIGURE.rst
+++ b/docs/CONFIGURE.rst
@@ -560,6 +560,22 @@ AppDaemon uses websockets as the default protocol for streaming events from AppD
     http:
         transport: socketio
 
+Additionally, arbitrary headers can be supplied in all server responses from AppDaemon with this configuration:
+
+.. code:: yaml
+
+    http:
+      headers:
+        My-Header-Here: "The Value Of My Header"
+
+Headers are especially useful for dealing with CORS. In order to allow CORS from any domain, consider the following configuration:
+
+.. code:: yaml
+
+    http:
+      headers:
+        Access-Control-Allow-Origin: "*"
+
 Configuring the Dashboard
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Since AppDaemon doesn't currently have a proper CORS setup, this is an interim solution.

WIth this PR, users can provider CORS (or any other header) with this in their appdaemon.yaml:

```yaml
http:
  url: http://127.0.0.1:5050
  headers:
    Access-Control-Allow-Origin: "*"
```
  