### PR TITLE
doc change

### DIFF
--- a/docs/DASHBOARD_CREATION.rst
+++ b/docs/DASHBOARD_CREATION.rst
@@ -1385,7 +1385,7 @@ Cosmetic Arguments
 -  ``widget_style``
 -  ``title_style``
 -  ``title2_style``
--  ``text_style``
+-  ``value_style`` - changes the style from the text
 
 light
 ~~~~~


### PR DESCRIPTION
label widget takes value_style and not text_style to change the style from the text.
the logical thing to do is to change the code, but it would mean a breaking change, so i changed the docs.