### PR TITLE
Authed and Filtered Stream

### DIFF
--- a/appdaemon/http.py
+++ b/appdaemon/http.py
@@ -146,7 +146,7 @@ class HTTP:
 
             # Setup event stream
 
-            self.stream = stream.ADStream(self.AD, self.app, self.transport, self.on_connect, self.on_message)
+            self.stream = stream.ADStream(self.AD, self.app, self.transport)
 
             self.loop = loop
             self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=5)
@@ -619,12 +619,6 @@ class HTTP:
         #self.logger.debug("stream_update() %s:%s", namespace, data)
         data["namespace"] = namespace
         self.AD.thread_async.call_async_no_wait(self.stream.send_update, data)
-
-    async def on_message(self, data):
-        self.access.info("New dashboard connected: %s", data)
-
-    async def on_connect(self):
-        pass
 
     # Routes, Status and Templates
 

--- a/appdaemon/http.py
+++ b/appdaemon/http.py
@@ -541,6 +541,22 @@ class HTTP:
             self.logger.warning('-' * 60)
             return self.get_response(request, 500, "Unexpected error in get_state()")
 
+    @securedata
+    async def get_logs(self, request):
+        try:
+            self.logger.debug("get_logs() called")
+
+            logs = await utils.run_in_executor(self, self.AD.logging.get_admin_logs)
+
+            return web.json_response({"logs": logs})
+        except:
+            self.logger.warning('-' * 60)
+            self.logger.warning("Unexpected error in get_logs()")
+            self.logger.warning('-' * 60)
+            self.logger.warning(traceback.format_exc())
+            self.logger.warning('-' * 60)
+            return self.get_response(request, 500, "Unexpected error in get_logs()")
+
     # noinspection PyUnusedLocal
     @securedata
     async def call_service(self, request):
@@ -620,6 +636,7 @@ class HTTP:
         self.app.router.add_get('/api/appdaemon/state/{namespace}/', self.get_namespace_entities)
         self.app.router.add_get('/api/appdaemon/state/', self.get_namespaces)
         self.app.router.add_get('/api/appdaemon/state', self.get_state)
+        self.app.router.add_get('/api/appdaemon/logs', self.get_logs)
         self.app.router.add_post('/api/appdaemon/{app}', self.call_api)
         self.app.router.add_get('/api/appdaemon', self.get_ad)
 

--- a/appdaemon/logging.py
+++ b/appdaemon/logging.py
@@ -388,8 +388,6 @@ class Logging:
 
         return logger
 
-    # Reading Logs
-
     # Run in executor
     def get_admin_logs(self):
         # Force main logs to be first in a specific order


### PR DESCRIPTION
The provides a framework for JSON based requests and responses in stream.

Requests are JSON arrays that contain a "request_type" key. The remaining keys are considered data for the request.

Responses come with a "response_type" key. Remaining response keys are considered data for the response.

The following requests types are established:

hello
Requires a client_name key
Accepts a password key with a plain text password
Accepts a cookie key with a browser authorization cookie
Will allow no password if none is set in AD config.

listen_state
Requires a namespace key. * wildcard supported at the end of the string
Requires an entity_id key. * wildcard supported at the end of the string

listen_event
Requires a namespace key. * wildcard supported at the end of the string.
Requires an event key. * wildcard supported at the end of the string.

get_state (test implementation)
Requires no parameters. Returns all states in AppDaemon

