### PR TITLE
Add attributes declared outside the `__init__` method to it.

### DIFF
--- a/appdaemon/app_management.py
+++ b/appdaemon/app_management.py
@@ -24,8 +24,8 @@ class AppManagement:
         self.monitored_files = {}
         self.filter_files = {}
         self.modules = {}
-
         self.objects = {}
+        self.check_app_updates_profile_stats = None
 
         # Initialize config file tracking
 

--- a/appdaemon/plugins/hass/hassplugin.py
+++ b/appdaemon/plugins/hass/hassplugin.py
@@ -100,6 +100,9 @@ class HassPlugin(PluginBase):
             self.plugin_startup_conditions = None
 
         self.session = None
+        self.first_time = False
+        self.already_notified = False
+        self.services = None
 
         self.logger.info("HASS Plugin initialization complete")
 


### PR DESCRIPTION
I found several attributes declared outside the `__init__` method. 
The best practice is to declare attributes in `__init__` before using them in other methods.
I just added those attributes to the `__init__` method.