### PR TITLE
Add default arg value and avoid unfilled arg warnings

### DIFF
--- a/appdaemon/dashboard.py
+++ b/appdaemon/dashboard.py
@@ -208,7 +208,7 @@ class Dashboard:
                 result[key] = line
         return result
    
-    def _do_subs(self, value, _vars):
+    def _do_subs(self, value, _vars={}):
         if isinstance(value, dict):
             result = {}
             templates = {}


### PR DESCRIPTION
Avoid warning by calling `_do_subs` with an unfilled arg                
For example:
dashboard.py
```
processed, t = self._do_subs(item) # line 224
```