### PR TITLE
ensure_future instead of await for async callbacks

### DIFF
--- a/appdaemon/threading.py
+++ b/appdaemon/threading.py
@@ -653,7 +653,8 @@ class Threading:
             # And Q
             #
             if asyncio.iscoroutinefunction(myargs["function"]):
-                await self.async_worker(myargs)
+                f = asyncio.ensure_future(self.async_worker(myargs))
+                self.AD.futures.add_future(name, f)
             else:
                 self.select_q(myargs)
             return True


### PR DESCRIPTION
by using ensure_future we leave the async worker pool unlocked to handle other tasks. 