### PR TITLE
Remove unnecessary "--virtual" from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apk add tzdata
 RUN pip3 install --no-cache-dir python-dateutil
 
 # Install dependencies
-RUN apk add --no-cache --virtual build-dependencies gcc libffi-dev musl-dev \
+RUN apk add --no-cache gcc libffi-dev musl-dev \
     && pip3 install --no-cache-dir .
 
 # Install additional packages


### PR DESCRIPTION
`--virtual` is used to create a virtual group of the packages in the command (to remove them at once for example (see here https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md#virtual-packages))

as we dont remove the build-deps anymore, giving them a name is useless