### PR TITLE
Http Fix

### DIFF
--- a/appdaemon/utility_loop.py
+++ b/appdaemon/utility_loop.py
@@ -55,7 +55,9 @@ class Utility:
         #
         # Start the web server
         #
-        await self.AD.http.start_server()
+        
+        if self.AD.http != None:
+            await self.AD.http.start_server()
 
         #
         # Wait for all plugins to initialize
@@ -181,7 +183,9 @@ class Utility:
             #
             # Shutdown webserver
             #
-            await self.AD.http.stop_server()
+            
+            if self.AD.http != None:
+                await self.AD.http.stop_server()
 
     async def set_production_mode(self, mode=True):
         if mode is True:

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -6,6 +6,9 @@ Change Log
 
 **Features**
 **Fixes**
+
+- Fixed an issue, where when ``http`` is disabled in ``appdaemon.yaml``, AD is unable to start
+
 **Breaking Changes**
 
 4.0.0 Beta 2 (2019-10-19)


### PR DESCRIPTION
Fix for when the user has `http:` disabled, so it doesn't crash AD.

Fix for #770 