### PR TITLE
added websocket event

### DIFF
--- a/appdaemon/stream.py
+++ b/appdaemon/stream.py
@@ -127,8 +127,12 @@ class ADStream:
             with self.streams_lock:
                 self.streams.pop(handle, None)
             
-            event_data = {'client_name' : rh.client_name}
-            await self.AD.events.fire_event('admin', 'websocket_disconnected', **event_data)
+            event_data = {
+                "event_type": "websocket_disconnected", 
+                    "data": {"client_name" : rh.client_name}
+                }
+
+            await self.AD.events.process_event("admin", event_data)
 
         return ws
 
@@ -294,9 +298,12 @@ class RequestHandler:
             "version": utils.__version__
         }
         
-        event_data = {'client_name' : data["client_name"]}
+        event_data = {
+                "event_type": "websocket_connected", 
+                    "data": {"client_name" : self.client_name}
+                }
 
-        await self.AD.events.fire_event('admin', 'websocket_connected', **event_data)
+        await self.AD.events.process_event("admin", event_data)
 
         return response_data
 

--- a/docs/APPGUIDE.rst
+++ b/docs/APPGUIDE.rst
@@ -1443,6 +1443,8 @@ Assistant bus:
    restart
 -  ``plugin_stopped`` - fired once every time AppDaemon loses its
    connection with HASS
+- ``websocket_connected`` - fired when a websocket client connects like the Admin User Interface
+- ``websocket_disconnected`` - fired when a websocket client disconnects like the Admin User Interface
 
 About Event Callbacks
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/APPGUIDE.rst
+++ b/docs/APPGUIDE.rst
@@ -1439,7 +1439,7 @@ Assistant bus:
    after Apps are initialized. It is fired within the `global` namespace
 - ``app_initialized`` - fired when an App is initialized. It is fired within the `admin` namespace
 - ``app_terminated`` - fired when an App is terminated. It is fired within the `admin` namespace
--  ``plugin_started`` - fired when a plugin is initialized properly setup e.g. connection 
+-  ``plugin_started`` - fired when a plugin is initialized and properly setup e.g. connection 
 to Home Assistant. It is fired within the plugin's namespace
 -  ``plugin_stopped`` - fired when a plugin terminates, or becomes internally unstable like a disconnection 
 from an external system like an MQTT broker. It is fired within the plugin's namespace

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -9,6 +9,7 @@ Change Log
 - Added events for when an app is initialized or terminated
 - Added `event_fire` service call
 - Added `production_mode` service call
+- Added events for when a webscoket client connects and disconnects
 
 **Fixes**
 


### PR DESCRIPTION
- Adds events that will be fired, when a websocket client connects and disconnects
- Adds the client name to the websocket handler class used for subscribing to stream, for better debugging
- The client name is used for demanding data from AD internals
- Update to AD's docs on events that are fired, and the namespaces it can be picked up from