### PR TITLE
Depreciation of loop argument

### DIFF
--- a/appdaemon/plugins/mqtt/mqttplugin.py
+++ b/appdaemon/plugins/mqtt/mqttplugin.py
@@ -98,7 +98,7 @@ class MqttPlugin(PluginBase):
         self.mqtt_client.on_message = self.mqtt_on_message
 
         self.loop = self.AD.loop # get AD loop
-        self.mqtt_connect_event = asyncio.Event(loop=self.loop)
+        self.mqtt_connect_event = asyncio.Event()
         self.mqtt_wildcards = list()
         self.mqtt_metadata = {
             "version": "1.0",


### PR DESCRIPTION
Removed the `loop` argument, as its not needed and to be removed soon as [here](https://docs.python.org/3/whatsnew/3.8.html#deprecated)