### PR TITLE
Allowed to cancel from other apps

### DIFF
--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -225,6 +225,7 @@ class ADAPI:
 
         Args:
             handle: The handle returned when the `listen_log` call was made.
+            name: The name of the app that the listen_log should be cancelled. Defaults to the calling app
 
         Returns:
             None.
@@ -1216,6 +1217,7 @@ class ADAPI:
 
         Args:
             handle: The handle returned when the ``listen_state()`` call was made.
+            name: The name of the app that the listen_state should be cancelled. Defaults to the calling app
 
         Returns:
             None.
@@ -1602,6 +1604,7 @@ class ADAPI:
 
         Args:
             handle: A handle returned from a previous call to ``listen_event()``.
+            name: The name of the app that the listen_event should be cancelled. Defaults to the calling app
 
         Returns:
             None.
@@ -1982,6 +1985,7 @@ class ADAPI:
 
         Args:
             handle: A handle value returned from the original call to create the timer.
+            name: The name of the app that the timer should be cancelled. Defaults to the calling app
 
         Returns:
             None.

--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -220,7 +220,7 @@ class ADAPI:
         return await self.AD.logging.add_log_callback(namespace, self.name, callback, level, **kwargs)
 
     @utils.sync_wrapper
-    async def cancel_listen_log(self, handle):
+    async def cancel_listen_log(self, handle, name=None):
         """Cancels the log callback for the App.
 
         Args:
@@ -233,8 +233,12 @@ class ADAPI:
               >>> self.cancel_listen_log(handle)
 
         """
-        self.logger.debug("Canceling listen_log for %s", self.name)
-        await self.AD.logging.cancel_log_callback(self.name, handle)
+
+        if name == None:
+            name= self.name
+
+        self.logger.debug("Canceling listen_log for %s", name)
+        await self.AD.logging.cancel_log_callback(name, handle)
 
     def get_main_log(self):
         """Returns the underlying logger object used for the main log.
@@ -1203,7 +1207,7 @@ class ADAPI:
         return await self.AD.state.add_state_callback(name, namespace, entity, callback, kwargs)
 
     @utils.sync_wrapper
-    async def cancel_listen_state(self, handle):
+    async def cancel_listen_state(self, handle, name=None):
         """Cancels a ``listen_state()`` callback.
 
         This will mean that the App will no longer be notified for the specific
@@ -1220,8 +1224,11 @@ class ADAPI:
             >>> self.cancel_listen_state(self.office_light_handle)
 
         """
-        self.logger.debug("Canceling listen_state for %s", self.name)
-        await self.AD.state.cancel_state_callback(handle, self.name)
+        if name == None:
+            name = self.name
+
+        self.logger.debug("Canceling listen_state for %s", name)
+        await self.AD.state.cancel_state_callback(handle, name)
 
     @utils.sync_wrapper
     async def info_listen_state(self, handle):
@@ -1590,7 +1597,7 @@ class ADAPI:
         return await self.AD.events.add_event_callback(_name, namespace, callback, event, **kwargs)
 
     @utils.sync_wrapper
-    async def cancel_listen_event(self, handle):
+    async def cancel_listen_event(self, handle, name=None):
         """Cancels a callback for a specific event.
 
         Args:
@@ -1603,8 +1610,12 @@ class ADAPI:
             >>> self.cancel_listen_event(handle)
 
         """
-        self.logger.debug("Canceling listen_event for %s", self.name)
-        await self.AD.events.cancel_event_callback(self.name, handle)
+
+        if name == None:
+            name = self.name
+
+        self.logger.debug("Canceling listen_event for %s", name)
+        await self.AD.events.cancel_event_callback(name, handle)
 
     @utils.sync_wrapper
     async def info_listen_event(self, handle):
@@ -1966,7 +1977,7 @@ class ADAPI:
     #
 
     @utils.sync_wrapper
-    async def cancel_timer(self, handle):
+    async def cancel_timer(self, handle, name=None):
         """Cancels a previously created timer.
 
         Args:
@@ -1979,8 +1990,11 @@ class ADAPI:
             >>> self.cancel_timer(handle)
 
         """
-        name = self.name
-        self.logger.debug("Canceling timer with handle %s for %s", handle, self.name)
+
+        if name == None:
+            name = self.name
+
+        self.logger.debug("Canceling timer with handle %s for %s", handle, name)
         await self.AD.sched.cancel_timer(name, handle)
 
     @utils.sync_wrapper


### PR DESCRIPTION
This allows the following across apps, by passing the app's name
- cancel_log
- cancel_listen_event
- cancel_listen_state
- cancel_timer

This should fix #778 