### PR TITLE
Namespace add to register service

### DIFF
--- a/appdaemon/services.py
+++ b/appdaemon/services.py
@@ -27,7 +27,7 @@ class Services:
             
             data = {
                 "event_type": "service_registered", 
-                    "data": {"domain": domain, "service" : service}
+                    "data": {"namespace": namespace, "domain": domain, "service" : service}
                 }
             self.AD.loop.create_task(self.AD.events.process_event(namespace, data))
 


### PR DESCRIPTION
Added `namespace` to the data sent by `service_registered` event, so it can be passed with the other parameters