### PR TITLE
Replace Attributes fix

### DIFF
--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -1330,7 +1330,7 @@ class ADAPI:
             replace(bool, optional): If a `replace` flag is given and set to ``True`` and ``attributes``
                 is provided, AD will attempt to replace its internal entity register with the newly
                 supplied attributes completely. This can be used to replace attributes in an entity
-                which are no longer needed. Do take note this is only pobbible for internal entity state.
+                which are no longer needed. Do take note this is only possible for internal entity state.
                 For plugin based entities, this is not recommended, as the plugin will mostly replace
                 the new values, when next it updates.
 

--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -1327,6 +1327,12 @@ class ADAPI:
                 if no namespace is given, AppDaemon will use the last specified namespace
                 or the default namespace. See the section on `namespaces <APPGUIDE.html#namespaces>`__
                 for a detailed description. In most cases, it is safe to ignore this parameter.
+            replace(bool, optional): If a `replace` flag is given and set to ``True`` and ``attributes``
+                is provided, AD will attempt to replace its internal entity register with the newly
+                supplied attributes completely. This can be used to replace attributes in an entity
+                which are no longer needed. Do take note this is only pobbible for internal entity state.
+                For plugin based entities, this is not recommended, as the plugin will mostly replace
+                the new values, when next it updates.
 
         Returns:
             A dictionary that represents the new state of the updated entity.

--- a/appdaemon/state.py
+++ b/appdaemon/state.py
@@ -374,10 +374,11 @@ class State:
             if "attributes" in kwargs:
                 new_state["attributes"].update(kwargs["attributes"])
             else:
-                if "replace" in kwargs:
-                    del kwargs["replace"]
-
-                new_state["attributes"].update(kwargs)
+                replace kwargs.pop("replace", False)
+                if replace is True:
+                    new_state["attributes"] = kwargs
+                else:
+                    new_state["attributes"].update(kwargs)
 
         return new_state
 

--- a/appdaemon/state.py
+++ b/appdaemon/state.py
@@ -374,7 +374,7 @@ class State:
             if "attributes" in kwargs:
                 new_state["attributes"].update(kwargs["attributes"])
             else:
-                replace kwargs.pop("replace", False)
+                replace = kwargs.pop("replace", False)
                 if replace is True:
                     new_state["attributes"] = kwargs
                 else:

--- a/appdaemon/state.py
+++ b/appdaemon/state.py
@@ -368,17 +368,13 @@ class State:
             new_state["state"] = kwargs["state"]
             del kwargs["state"]
 
-        if "attributes" in kwargs and kwargs.get('replace', False):
-            new_state["attributes"] = kwargs["attributes"]
-        else:
-            if "attributes" in kwargs:
-                new_state["attributes"].update(kwargs["attributes"])
+        if "attributes" in kwargs:
+            if kwargs.get('replace', False):
+                new_state["attributes"] = kwargs["attributes"]
             else:
-                replace = kwargs.pop("replace", False)
-                if replace is True:
-                    new_state["attributes"] = kwargs
-                else:
-                    new_state["attributes"].update(kwargs)
+                new_state["attributes"].update(kwargs["attributes"])
+        else:
+             new_state["attributes"].update(kwargs)
 
         return new_state
 


### PR DESCRIPTION
If the replace flag was used in `set_state` without `attributes`, it didn't work properly.

This fix ensures as long as the replace flag is used, it will always replace the attributes supplied