### PR TITLE
Plugin Services

### DIFF
--- a/appdaemon/plugin_management.py
+++ b/appdaemon/plugin_management.py
@@ -178,7 +178,6 @@ class Plugins:
             self.plugin_objs[namespace]["object"].stop()
 
             name = self.plugin_objs[namespace]["name"]
-            self.AD.http.stream.stream_unregister(name)
 
             del self.plugin_objs[namespace] # remove the plugin object
             self.AD.loop.create_task(self.set_state(name, state="stopped"))

--- a/appdaemon/plugin_management.py
+++ b/appdaemon/plugin_management.py
@@ -183,7 +183,10 @@ class Plugins:
             self.AD.loop.create_task(self.set_state(name, state="stopped"))
 
             if not self.stopping:
-                self.AD.loop.create_task(self.AD.events.process_event(namespace, {"event_type": "plugin_stopped", "data": {"name": name}}))
+                self.AD.loop.create_task(
+                    self.AD.events.process_event(
+                        namespace, {"event_type": "plugin_stopped", "data": {"name": name}})
+                )
 
     def restart_plugin(self, plugin):
         for namespace in self.plugin_objs:

--- a/appdaemon/plugin_management.py
+++ b/appdaemon/plugin_management.py
@@ -139,8 +139,12 @@ class Plugins:
     def stop_plugin(self, namespace):
         if namespace in self.plugin_objs:
             self.plugin_objs[namespace]["object"].stop()
+
             name = self.plugin_objs[namespace]["name"]
+            self.AD.http.stream.stream_unregister(name)
+
             del self.plugin_objs[namespace] # remove the plugin object
+            print(namespace, " been removed")
 
             if not self.stopping:
                 self.AD.loop.create_task(self.AD.events.process_event(namespace, {"event_type": "plugin_stopped", "data": {"name": name}}))
@@ -241,6 +245,7 @@ class Plugins:
     async def notify_plugin_stopped(self, name, namespace):
         if not self.stopping:
             if namespace in self.plugin_objs: # meaning it wasn't stopped by a service
+                print(namespace, " been stopped")
                 self.plugin_objs[namespace]["active"] = False
                 await self.AD.events.process_event(namespace, {"event_type": "plugin_stopped", "data": {"name": name}})
 

--- a/appdaemon/plugins/hass/hassplugin.py
+++ b/appdaemon/plugins/hass/hassplugin.py
@@ -114,6 +114,7 @@ class HassPlugin(PluginBase):
     def stop(self):
         self.logger.debug("stop() called for %s", self.name)
         self.stopping = True
+        self.reading_messages = False
         if self.ws is not None:
             self.ws.close()
             

--- a/appdaemon/plugins/hass/hassplugin.py
+++ b/appdaemon/plugins/hass/hassplugin.py
@@ -116,6 +116,9 @@ class HassPlugin(PluginBase):
         self.stopping = True
         if self.ws is not None:
             self.ws.close()
+            
+        if self.session is not None:
+            self.session.close()
 
     #
     # Get initial state

--- a/appdaemon/plugins/hass/hassplugin.py
+++ b/appdaemon/plugins/hass/hassplugin.py
@@ -118,7 +118,7 @@ class HassPlugin(PluginBase):
             self.ws.close()
             
         if self.session is not None:
-            self.session.close()
+            self.AD.loop.create_task(self.session.close())
 
     #
     # Get initial state

--- a/docs/AD_API_REFERENCE.rst
+++ b/docs/AD_API_REFERENCE.rst
@@ -167,6 +167,30 @@ Sets the production mode AD is running on. The value of the `mode` arg has to be
 
 >>> self.call_service("production_mode/set", mode=True, namespace="appdaemon")
 
+**plugin/start**
+
+Starts an already stopped plugin. If the plugin is diabled, it wouldn't be able to start it, unless its enabled first using the enable service
+
+>>> self.call_service("plugin/start", plugin="HASS", namespace="appdaemon")
+
+**plugin/stop**
+
+Stops an already started plugin.
+
+>>> self.call_service("plugin/stop", plugin="HASS", namespace="appdaemon")
+
+**plugin/restart**
+
+Stops and Starts a plugin
+
+>>> self.call_service("plugin/restart", plugin="HASS", namespace="appdaemon")
+
+**plugin/enable**
+
+Enables an already disabled plugin, which has been set in the configuration file. This service will only enable it, and will not start the plugin.
+
+>>> self.call_service("plugin/enable", plugin="MQTT", namespace="appdaemon")
+
 All namespaces except ``appdaemon``, ``global``, and ``admin``:
 
 **state/set**

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -14,6 +14,7 @@ Change Log
 - Added the ability to use async functions as endpoint callback
 - Added the ability for `input_select` to auto-update when the options changes, without need of refreshing the browser page
 - Added events for when a webscoket client connects and disconnects
+- Added ability to start, stop, restart and enable plugins
 
 **Fixes**
 


### PR DESCRIPTION
This PR adds the ability to start, stop, restart and enable an already disabled plugin. There is no reload, so if a change is made to the plugin python file or configuration in appdaemon.yaml, this will not get the changes.

This also adds entities in the admin interface, representing the state of each plugin 