### PR TITLE
Correct logfile to filename

### DIFF
--- a/docs/CONFIGURE.rst
+++ b/docs/CONFIGURE.rst
@@ -63,7 +63,7 @@ All directives are optional with the exception of ``name`` for user defined logs
 
 The directives are as follows:
 
--  ``logfile`` (optional) is the path to where you want the file to be written. If the directive is not
+-  ``filename`` (optional) is the path to where you want the file to be written. If the directive is not
    specified, the output is sent to STDOUT.
 -  ``log_size`` (optional) is the maximum size a logfile will get to
    before it is rotated if not specified, this will default to 1000000


### PR DESCRIPTION
The docs mention ``logfile`` whereas the code shows that the parameter in the dict should be ``filename``.

I figured that was overlooked =)