### PR TITLE
Install g++ inside docker container to allow compiling python grpcio

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY . .
 RUN apk add tzdata
 
 # Install dependencies
-RUN apk add --no-cache gcc libffi-dev musl-dev \
+RUN apk add --no-cache gcc g++ libffi-dev musl-dev \
     && pip install --no-cache-dir .
 
 # Install additional packages


### PR DESCRIPTION
The current image fails to compile python grpc library since there are missing c++ libraries in the docker image.
```
read
    gcc: fatal error: cannot execute 'cc1plus': execvp: No such file or directory
    compilation terminated.
    creating tmp/tmp35fj7yvc
    gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -DTHREAD_STACK_SIZE=0x100000 -fPIC -I/usr/local/include/python3.8 -c /tmp/tmp35fj7yvc/a.c -o tmp/t
```

This change installs g++ during docker build so that we can compile successfully