### PR TITLE
Fix leap year bug

### DIFF
--- a/appdaemon/scheduler.py
+++ b/appdaemon/scheduler.py
@@ -341,7 +341,7 @@ class Scheduler:
 
     def get_next_entries(self):
 
-        next_exec = datetime.datetime.now(pytz.utc).replace(year=3000)
+        next_exec = datetime.datetime.now(pytz.utc).replace(year=3200)
         for name in self.schedule.keys():
             for entry in self.schedule[name].keys():
                 if self.schedule[name][entry]["timestamp"] < next_exec:


### PR DESCRIPTION
Leap years are divisible by 4, except if evenly divisible by 100, unless its also divisible by 400

Year 3000 isn't a leap year, so when replacing year on Feb 29 of a leap year, it crashes