### PR TITLE
Correctly return the timezone offset in get_tz_offset

### DIFF
--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -1778,22 +1778,14 @@ class ADAPI:
             utc_string (str): A string that contains a date and time to convert.
 
         Returns:
-            An UTC object that is equivalent to the date and time contained in `utc_string`.
+            An POSIX timestamp that is equivalent to the date and time contained in `utc_string`.
 
         """
         return datetime.datetime(*map(int, re.split(r"[^\d]", utc_string)[:-1])).timestamp() + self.get_tz_offset() * 60
 
-    @staticmethod
-    def get_tz_offset():
-        """Returns the timezone difference between UTC and Local Time."""
-        utc_offset_min = (
-            int(round((datetime.datetime.now() - datetime.datetime.utcnow()).total_seconds())) / 60
-        )  # round for taking time twice
-        utc_offset_h = utc_offset_min / 60
-
-        # we do not handle 1/2 h timezone offsets
-        assert utc_offset_min == utc_offset_h * 60
-        return utc_offset_min
+    def get_tz_offset(self):
+        """Returns the timezone difference between UTC and Local Time in minutes."""
+        return self.AD.tz.utcoffset(self.datetime()).total_seconds() / 60
 
     @staticmethod
     def convert_utc(utc):


### PR DESCRIPTION
As per #910, the current implementation of `get_tz_offset()` is always returning zero. This change addresses that.

That said, after looking at this a bit, I'm thinking that `get_tz_offset()` should probably return seconds rather than minutes (keen for feedback), or a `timedelta` object.

I also noticed that`parse_utc_string()` docstring does not match what it does (I have fixed that). However I think it should probably also go as we have `parse_datetime`, and returning a timestamp which is typically in UTC already feels a bit weird (but maybe I'm misunderstanding how it could be used). I didn't see any uses of it on the internet, so image it's not a big one. It could also raise a `DepreciationWarning`, with a view to remove it down the track.

Keen for any thoughts and happy to integrate them as well.

PS: I also noticed that the code is not formatted with `black` (like HA is), I'm also happy to look at doing that (in another PR), and putting in a config for vscode to do this automatically (also copied from HA).  Cheers.