### PR TITLE
Stream fix

### DIFF
--- a/appdaemon/stream/adstream.py
+++ b/appdaemon/stream/adstream.py
@@ -63,8 +63,8 @@ class ADStream:
                 if len(self.handlers) > 0:
                     # self.logger.debug("Sending data: %s", data)
                     for handler in self.handlers:
-                        if self.handlers[handler].authed is True: # if authenticated
-                            #await self.handlers[handler]._event(data)
+                        if self.handlers[handler].authed is True:  # if authenticated
+                            # await self.handlers[handler]._event(data)
                             asyncio.ensure_future(self.handlers[handler]._event(data))
 
         except Exception:
@@ -245,7 +245,7 @@ class RequestHandler:
 
         if not self.authed:
             raise RequestHandlerException("authorization failed")
-        
+
         self.stream.set_client_name(self.client_name)
 
         self.access.info("New client %s connected", data["client_name"])

--- a/appdaemon/stream/adstream.py
+++ b/appdaemon/stream/adstream.py
@@ -2,6 +2,7 @@ import traceback
 import bcrypt
 import uuid
 import threading
+import asyncio
 
 from appdaemon.appdaemon import AppDaemon
 import appdaemon.utils as utils
@@ -62,7 +63,9 @@ class ADStream:
                 if len(self.handlers) > 0:
                     # self.logger.debug("Sending data: %s", data)
                     for handler in self.handlers:
-                        await self.handlers[handler]._event(data)
+                        if self.handlers[handler].authed is True: # if authenticated
+                            #await self.handlers[handler]._event(data)
+                            asyncio.ensure_future(self.handlers[handler]._event(data))
 
         except Exception:
             self.logger.warning("-" * 60)
@@ -242,6 +245,8 @@ class RequestHandler:
 
         if not self.authed:
             raise RequestHandlerException("authorization failed")
+        
+        self.stream.set_client_name(self.client_name)
 
         self.access.info("New client %s connected", data["client_name"])
         response_data = {"version": utils.__version__}

--- a/appdaemon/stream/ws_handler.py
+++ b/appdaemon/stream/ws_handler.py
@@ -41,7 +41,7 @@ class WSStream:
         self.logger = ad.logging.get_child("_stream")
         self.access = ad.logging.get_access()
         self.client_name = kwargs.get("client_name")
-    
+
     def set_client_name(self, client_name):
         self.client_name = client_name
 
@@ -82,7 +82,7 @@ class WSStream:
         try:
             async with self.lock:
                 await self.ws.send_json(data, dumps=utils.convert_json)
-                
+
         except TypeError as e:
             self.logger.debug("-" * 60)
             self.logger.warning("Unexpected error in JSON conversion when writing to stream from %s", self.client_name)


### PR DESCRIPTION
This fix helps with the following

- Allows for setting of client name, so when websockets disconnects, helps with debugging
- When there is a slow connected websocket client, due to the number of events to be transmitted, it can lead to a lot of issues in connection and it keeps disconnecting and reconnecting. To avoid this, a lock is introduced.
- In addition to the above, this can affect other connected streams, and to fix this, used `ensure_future` so it doesn't affect other streams
- Lastly when a client is connected, stream wouldn't be sent to the client unless the client has been authenticated 

Regards  