### PR TITLE
Log message fix

### DIFF
--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -57,18 +57,13 @@ class ADAPI:
     def _sub_stack(msg):
         # If msg is a data structure of some type, don't sub
         if type(msg) is str:
-            try:
-                stack = inspect.stack()
-                if msg.find("__module__") != -1:
-                    msg = msg.replace("__module__", stack[2][1])
-                if msg.find("__line__") != -1:
-                    msg = msg.replace("__line__", str(stack[2][2]))
-                if msg.find("__function__") != -1:
-                    msg = msg.replace("__function__", stack[2][3])
-
-            except IndexError:
-                pass
-
+            stack = inspect.stack()
+            if msg.find("__module__") != -1:
+                msg = msg.replace("__module__", stack[2][1])
+            if msg.find("__line__") != -1:
+                msg = msg.replace("__line__", str(stack[2][2]))
+            if msg.find("__function__") != -1:
+                msg = msg.replace("__function__", stack[2][3])
         return msg
 
     def _get_namespace(self, **kwargs):
@@ -148,7 +143,11 @@ class ADAPI:
         else:
             logger = self.logger
 
-        msg = self._sub_stack(msg)
+        try:
+            msg = self._sub_stack(msg)
+        except IndexError as i:
+            kwargs["level"] = "ERROR"
+            self._log(self.err, i, *args, **kwargs)
 
         self._log(logger, msg, *args, **kwargs)
 

--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -57,13 +57,18 @@ class ADAPI:
     def _sub_stack(msg):
         # If msg is a data structure of some type, don't sub
         if type(msg) is str:
-            stack = inspect.stack()
-            if msg.find("__module__") != -1:
-                msg = msg.replace("__module__", stack[2][1])
-            if msg.find("__line__") != -1:
-                msg = msg.replace("__line__", str(stack[2][2]))
-            if msg.find("__function__") != -1:
-                msg = msg.replace("__function__", stack[2][3])
+            try:
+                stack = inspect.stack()
+                if msg.find("__module__") != -1:
+                    msg = msg.replace("__module__", stack[2][1])
+                if msg.find("__line__") != -1:
+                    msg = msg.replace("__line__", str(stack[2][2]))
+                if msg.find("__function__") != -1:
+                    msg = msg.replace("__function__", stack[2][3])
+
+            except IndexError:
+                pass
+
         return msg
 
     def _get_namespace(self, **kwargs):


### PR DESCRIPTION
This fixes an issue whereby I get an error like the below sometimes
```
2020-03-17 09:22:11.369648 WARNING living_room_camera: ------------------------------------------------------------
2020-03-17 09:22:11.370238 WARNING living_room_camera: Unexpected error running terminate() for living_room_camera
2020-03-17 09:22:11.370692 WARNING living_room_camera: ------------------------------------------------------------
2020-03-17 09:22:11.374190 WARNING living_room_camera: Traceback (most recent call last):
  File "/usr/lib/python3.8/site-packages/appdaemon/app_management.py", line 184, in terminate_app
    await term()
  File "/config/apps/camera/camera.py", line 1227, in terminate
  File "/config/apps/camera/camera.py", line 345, in stop_capturing
    self.adapi.log("Stopping camera video capturing")
  File "/usr/lib/python3.8/site-packages/appdaemon/adapi.py", line 146, in log
    msg = self._sub_stack(msg)
  File "/usr/lib/python3.8/site-packages/appdaemon/adapi.py", line 60, in _sub_stack
    stack = inspect.stack()
  File "/usr/lib/python3.8/inspect.py", line 1514, in stack
    return getouterframes(sys._getframe(1), context)
  File "/usr/lib/python3.8/inspect.py", line 1491, in getouterframes
    frameinfo = (frame,) + getframeinfo(frame, context)
  File "/usr/lib/python3.8/inspect.py", line 1465, in getframeinfo
    lines, lnum = findsource(frame)
  File "/usr/lib/python3.8/inspect.py", line 840, in findsource
    if pat.match(lines[lnum]): break
IndexError: list index out of range

2020-03-17 09:22:11.374507 WARNING living_room_camera: ------------------------------------------------------------
```
it sometimes leads to the app not terminating properly, which makes it not to start well sometimes