### PR TITLE
remove references of deprecated "return_result"

### DIFF
--- a/appdaemon/entity.py
+++ b/appdaemon/entity.py
@@ -355,8 +355,6 @@ class Entity:
 
         Args:
             service (str): The service name, without the domain (e.g "toggle")
-            return_result(bool, option): If `return_result` is provided and set to `True` AD will attempt
-                to wait for the result, and return it after execution
             callback: The non-async callback to be executed when complete.
             **kwargs: Each service has different parameter requirements. This argument
                 allows you to specify a comma-separated list of keyword value pairs, e.g.,

--- a/appdaemon/models/config/plugin.py
+++ b/appdaemon/models/config/plugin.py
@@ -100,7 +100,6 @@ class HASSConfig(PluginConfig):
         BeforeValidator(utils.parse_timedelta)
     ] = Field(default_factory=lambda: timedelta(seconds=10))
     """Default timeout for waiting for responses from the websocket connection"""
-    # return_result: bool | None = None
     suppress_log_messages: bool = False
     retry_secs: int = 5
     services_sleep_time: int = 60

--- a/docs/CONFIGURE.rst
+++ b/docs/CONFIGURE.rst
@@ -517,8 +517,6 @@ To configure the HASS plugin, in addition to the required parameters above, you 
 -  ``retry_secs`` (optional) - If specified, AD will wait for this many seconds in between retries to connect to HASS (default 5 seconds)
 -  ``plugin_startup_conditions`` - see `HASS Plugin Startup Conditions <#startup-conditions>`__
 -  ``q_timeout`` (optional, 30 seconds) - amount of time to wait for a response from Home Assistant before returning an error
--  ``return_result`` (optional, false) - if set to true, all service calls to Home Assistant will wait for a response. Whether or not this returns data,
-   it can also provide error checking, and accurate timing for how long service calls take. Will be overridden by the ``return_result`` argument in ``call_service()``
 -  ``suppress_log_messages`` - (optional, false) - if set to true, all ``call_service()`` related log messages will be suppressed by default. Will be overridden by the ``suppress_log_messages`` argument in ``call_service()``
 
 For example:


### PR DESCRIPTION
Unless I'm mistaken, `return_result` has been completely removed.  This tiny PR removes a few mentions of it from the doc, to prevent confusion.