### PR TITLE
Feature/add skin to navigate

### DIFF
--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -3294,7 +3294,7 @@ class ADAPI:
     # Dashboard
     #
 
-    def dash_navigate(self, target: str, timeout: int = -1, ret: str | None = None, sticky: int = 0, deviceid: str | None = None, dashid: str | None = None) -> None:
+    def dash_navigate(self, target: str, timeout: int = -1, ret: str | None = None, sticky: int = 0, deviceid: str | None = None, dashid: str | None = None, skin: str | None = None) -> None:
         """Forces all connected Dashboards to navigate to a new URL.
 
         Args:
@@ -3315,6 +3315,7 @@ class ADAPI:
             dashid (str): If set, all devices currently on a dashboard which the title contains
                 the substring dashid will navigate. ex: if dashid is "kichen", it will match
                 devices which are on "kitchen lights", "kitchen sensors", "ipad - kitchen", etc.
+            skin (str): If set, the skin will change to the skin defined on the param.
 
         Returns:
             None.
@@ -3339,6 +3340,8 @@ class ADAPI:
             kwargs["deviceid"] = deviceid
         if dashid is not None:
             kwargs["dashid"] = dashid
+        if skin is not None:
+            kwargs["skin"] = skin
         self.fire_event("ad_dashboard", **kwargs)
 
     #

--- a/appdaemon/assets/javascript/dashboard.js
+++ b/appdaemon/assets/javascript/dashboard.js
@@ -19,7 +19,7 @@ function setCookie(cname, cvalue) {
 }
 
 function getQueryStringParams() {
-    var query = location.search.substring(1); 
+    var query = location.search.substring(1);
     // Parse existing query string if it exists
     var query_params = [];
     if (query) {
@@ -29,14 +29,14 @@ function getQueryStringParams() {
 }
 
 function setQueryStringParam(query_params, param_name, new_value) {
-    // Remove existing skin parameter if present
+    // Remove existing parameter if present
     for (var i = 0; i < query_params.length; i++) {
         if (query_params[i].startsWith(param_name + "=")) {
             query_params.splice(i, 1);
             break;
         }
     }
-    // Add new skin parameter
+    // Add new parameter
     var param = param_name + "=" + encodeURIComponent(new_value);
     query_params.push(param);
     return query_params;
@@ -128,7 +128,7 @@ var DashStream = function(transport, protocol, domain, port, title, widgets)
             if (data.data.command === "navigate")
             {
                 var query_params = getQueryStringParams();
-                if ("skin" in data.data) 
+                if ("skin" in data.data)
                 {
                     query_params = setQueryStringParam(query_params, "skin", data.data.skin)
                 }

--- a/appdaemon/assets/javascript/dashboard.js
+++ b/appdaemon/assets/javascript/dashboard.js
@@ -18,6 +18,30 @@ function setCookie(cname, cvalue) {
     document.cookie = cname + "=" + cvalue + "; expires=Sat, 1 Jan 2050 12:00:00 UTC;";
 }
 
+function getQueryStringParams() {
+    var query = location.search.substring(1); 
+    // Parse existing query string if it exists
+    var query_params = [];
+    if (query) {
+        query_params = query.split('&');
+    }
+    return query_params;
+}
+
+function setQueryStringParam(query_params, param_name, new_value) {
+    // Remove existing skin parameter if present
+    for (var i = 0; i < query_params.length; i++) {
+        if (query_params[i].startsWith(param_name + "=")) {
+            query_params.splice(i, 1);
+            break;
+        }
+    }
+    // Add new skin parameter
+    var param = param_name + "=" + encodeURIComponent(new_value);
+    query_params.push(param);
+    return query_params;
+}
+
 function get_monitored_entities(widgets)
 {
     index = 0;
@@ -103,38 +127,21 @@ var DashStream = function(transport, protocol, domain, port, title, widgets)
         {
             if (data.data.command === "navigate")
             {
-                var timeout_params = "";
+                var query_params = getQueryStringParams();
+                if ("skin" in data.data) 
+                {
+                    query_params = setQueryStringParam(query_params, "skin", data.data.skin)
+                }
                 if ("timeout" in data.data)
                 {
-                    var timeout = data.data.timeout;
-                    if (location.search === "")
-                    {
-                        timeout_params = "?";
-                    }
-                    else
-                    {
-                        timeout_params = "&";
-                    }
-                    if ("return" in data.data)
-                    {
-                        ret = data.data.return
-                    }
-                    else
-                    {
-                        ret = location.pathname
-                    }
-                    if ("sticky")
-                    {
-                        sticky = data.data.sticky;
-                    }
-                    else
-                    {
-                        sticky = 0;
-                    }
-
-                    timeout_params += "timeout=" + timeout + "&return=" + ret + "&sticky=" + sticky;
+                    query_params.push("timeout=" + data.data.timeout)
+                    var ret = "return" in data.data ? data.data.return : location.pathname
+                    query_params.push("return=" + ret)
+                    query_params.push("sticky=" + data.data.sticky)
                 }
-                window.location.href = data.data.target + location.search + timeout_params;
+                // Rebuild query string with existing params
+                var new_query_params = query_params.length > 0 ? "?" + query_params.join("&") : "";
+                window.location.href = data.data.target + new_query_params;
             }
         }
         Object.keys(widgets).forEach(function (key) {


### PR DESCRIPTION
# Pull Request Description for dash_navigate Skin Parameter Feature

## Title
Add skin parameter to dash_navigate function for dynamic theme switching

## Description

This PR adds a new optional `skin` parameter to the `dash_navigate` function, allowing users to change dashboard skins/themes during navigation. 

### What this PR accomplishes:

- Extends the `dash_navigate` function to accept and process a `skin` parameter
- Maintains backward compatibility with existing code (parameter is optional)
- Tiny refactor on the update_dash function for better handling of the query params
- I've tried to avoid any new features from JS as I think this project tries to keep compatibility with older browsers (my own case - IPad 3)

### Use case:
- Implementing power-saving modes for dashboards (switching to a dark theme when a room is vacant)

### Example usage:
```python
# Switch to a dashboard with a specific skin
self.dash_navigate("main_dashboard", skin="dark")

# Standard usage without skin parameter still works
self.dash_navigate("settings_dashboard")
```

### Testing:
I've tested this functionality and verified that the skin parameter correctly applies the specified theme during navigation while preserving all existing functionality.

Closes #2345