### PR TITLE
Add callback argument to Dashboard's call_service

### DIFF
--- a/appdaemon/assets/javascript/dashboard.js
+++ b/appdaemon/assets/javascript/dashboard.js
@@ -326,7 +326,7 @@ var WidgetBase = function(widget_id, url, skin, parameters, monitored_entities, 
         }
     };
 
-    this.call_service = function(child, args)
+    this.call_service = function(child, args, callback)
     {
         if ("resident_namespace" in child.parameters)
         {
@@ -339,7 +339,7 @@ var WidgetBase = function(widget_id, url, skin, parameters, monitored_entities, 
 
         service = args["service"];
 
-        window.dashstream.stream.call_service(service, ns, args)
+        window.dashstream.stream.call_service(service, ns, args, callback)
     };
 
     // Initialization


### PR DESCRIPTION
Callback is possible on all `call_service` functions but not on the `dashboard.js` one.
I'd like it for a widget I'm working on for my dashboard (https://github.com/psolyca/appdaemon_weatherentity)