### PR TITLE
Fix refresh_update_time call with plugin name

### DIFF
--- a/appdaemon/plugin_management.py
+++ b/appdaemon/plugin_management.py
@@ -536,7 +536,7 @@ class PluginManagement:
                             ns = cfg.namespace
                         self.AD.state.update_namespace_state(ns, state)
                 finally:
-                    await self.refresh_update_time(plugin)
+                    await self.refresh_update_time(plugin.name)
 
     def required_meta_check(self):
         OK = True


### PR DESCRIPTION
I noticed that since upgrading to 4.5.X, AppDaemon generates way more traffic between itself and Home Assistant. It generates a continues stream of about 1 Mbps. It turns out that it keeps on getting full state updates every second once the initial `refresh_delay` has expired.

The issue is that the `last_plugin_state` dictionary is incorrectly updated with the entire plugin instead of just the plugin name. Because of this, the HASS plugin timestamp is never updated, causing it to remain expired and triggering a full state update every second. Providing the plugin name when refreshing the update time fixes the issue.

I'm wondering why this hasn't come to the surface before because it looks like a critical issue to me.

Traffic generated before the fix (before 20:46:00):
<img width="721" height="336" alt="image" src="https://github.com/user-attachments/assets/bea70087-1db8-4f42-8891-f20037d18ee4" />

Traffic generated after the fix (after 21:19:00, the single spike is because of a package update that's not related to AppDaemon):
<img width="716" height="333" alt="image" src="https://github.com/user-attachments/assets/dc847ddc-7888-45af-abeb-f259008f24e6" />
