### PR TITLE
reload modified apps on SIGUSR2

### DIFF
--- a/appdaemon/__main__.py
+++ b/appdaemon/__main__.py
@@ -341,6 +341,7 @@ class ADMain:
 
         Signals:
             SIGUSR1 will result in internal info being dumped to the DIAG log
+            SIGUSR2 will reload apps with modified code/config (useful in production_mode)
             SIGHUP will force a reload of all apps
             SIGINT and SIGTEM both result in AD shutting down
         """
@@ -351,6 +352,8 @@ class ADMain:
                 self.AD.thread_async.call_async_no_wait(self.AD.threading.dump_threads)
                 self.AD.thread_async.call_async_no_wait(self.AD.app_management.dump_objects)
                 self.AD.thread_async.call_async_no_wait(self.AD.sched.dump_sun)
+            case signal.SIGUSR2:
+                self.AD.thread_async.call_async_no_wait(self.AD.app_management.check_app_updates, mode=UpdateMode.NORMAL)
             case signal.SIGHUP:
                 self.AD.thread_async.call_async_no_wait(self.AD.app_management.check_app_updates, mode=UpdateMode.TERMINATE)
             case (signal.SIGINT | signal.SIGTERM) as sig:


### PR DESCRIPTION
This tiny PR makes AppDaemon check for modified apps (and reload them) when SIGUSR2 is received.

This is similar to SIGHUP (which reloads all apps,) but only reloads modified ones. It is useful in `production_mode` in which modification checks do not happen automatically. So one can upload the code, send SIGUSR2 and have AppDaemon quickly reload only what's needed.