### PR TITLE
Removed incorrect option for mqtt connection

### DIFF
--- a/appdaemon/plugins/mqtt/mqttplugin.py
+++ b/appdaemon/plugins/mqtt/mqttplugin.py
@@ -523,7 +523,7 @@ class MqttPlugin(PluginBase):
                     retain=self.config.will_retain,
                 )
 
-            self.mqtt_client.connect_async(self.config.client_host, self.config.client_port, self.config.tls_version)
+            self.mqtt_client.connect_async(self.config.client_host, self.config.client_port)
             self.mqtt_client.loop_start()
         except Exception as e:
             self.logger.critical(


### PR DESCRIPTION
**TLDR: Removed tls_version passed to paho-mqtt connect_async as the third argument, because the third argument is supposed to be keepAlive (defaults to 60).**

### Background
I was troubleshooting an issue where I found that AppDaemon was occasionally forcefully disconnected from my MQTT broker (Mosquitto), causing all my sensors becoming "unavailable" for a short period.

### AppDaemon logs
```
CRITICAL MQTT: MQTT Client Disconnected Abruptly. Will attempt reconnection
CRITICAL MQTT: MQTT Plugin Stopped Unexpectedly
CRITICAL MQTT: Unable to reinitialize MQTT Plugin, will keep trying again until complete
INFO AppDaemon: Stopping apps from namespace 'mqtt' because the plugin failed
INFO MQTT: Connected to MQTT broker at URL 192.168.10.132:1883 with paho-mqtt
INFO MQTT: MQTT Plugin initialization complete
```

### Mosquitto logs
```
Client AppDaemon has exceeded timeout, disconnecting
```

The reason for the disconnect was due to Mosquitto not receiving PINGREQ message in time, based on the keepAlive time that the client informed broker about upon initial connection. I then investigated what keepAlive time AppDaemon uses, and that's when I found that we pass an unexpected value (tls_version) when setting keepAlive. I have tried to find the reason why the code looks like this, but I have not found a reason yet.

Since correcting this, the MQTT connection for AppDaemon is perfectly stable.