### PR TITLE
fixed/simplified default ssl context

### DIFF
--- a/appdaemon/plugins/hass/hassplugin.py
+++ b/appdaemon/plugins/hass/hassplugin.py
@@ -111,11 +111,8 @@ class HassPlugin(PluginBase):
         """Handles creating an :py:class:`~aiohttp.ClientSession` with the cert information from the plugin config
         and the authorization headers for the `REST API <https://developers.home-assistant.io/docs/api/rest>`_.
         """
-        if self.config.cert_path is not None:
-            ssl_context = ssl.create_default_context(capath=self.config.cert_path)
-            conn = aiohttp.TCPConnector(ssl_context=ssl_context, verify_ssl=self.config.cert_verify)
-        else:
-            conn = aiohttp.TCPConnector(ssl=False)
+        ssl_context = ssl.create_default_context(capath=self.config.cert_path)
+        conn = aiohttp.TCPConnector(ssl_context=ssl_context)
 
         connect_timeout_secs = self.config.connect_timeout.total_seconds()
         return aiohttp.ClientSession(

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -8,8 +8,9 @@ None
 
 **Fixes**
 
-Fix for sunrise and sunset with offsets - contributed by [ekutner](https://github.com/ekutner)
-Fix for random MQTT disconnects  - contributed by [Xsandor](https://github.com/Xsandor)
+- Fix for sunrise and sunset with offsets - contributed by [ekutner](https://github.com/ekutner)
+- Fix for random MQTT disconnects  - contributed by [Xsandor](https://github.com/Xsandor)
+- Fix for connecting to Home Assistant with https
 
 **Breaking Changes**
 


### PR DESCRIPTION
This makes regular https connections work. Self-signed certs still need additional config options

Fixes #2448