### PR TITLE
Fix reading of http password and ha_key

### DIFF
--- a/appdaemon/http.py
+++ b/appdaemon/http.py
@@ -162,6 +162,8 @@ class HTTP:
         self.static_dirs = {}
 
         self._process_http(self.http)
+        if (cfg := main_cfg.http) is not None and (p := cfg.password) is not None:
+            self.password = p.get_secret_value()  # read secret directly
 
         self.app_endpoints = {}
         self.app_routes = {}
@@ -386,7 +388,6 @@ class HTTP:
         self.setup_dashboard_routes()
 
     def _process_http(self, http):
-        self._process_arg("password", http)
         self._process_arg("tokens", http)
         self._process_arg("work_factor", http)
         self._process_arg("ssl_certificate", http)

--- a/appdaemon/models/config/plugin.py
+++ b/appdaemon/models/config/plugin.py
@@ -140,7 +140,7 @@ class HASSConfig(PluginConfig, extra="forbid"):
         if self.token is not None:
             return {"Authorization": f"Bearer {self.token.get_secret_value()}"}
         elif self.ha_key is not None:
-            return {"x-ha-access": self.ha_key}
+            return {"x-ha-access": self.ha_key.get_secret_value()}
         raise ValueError("Home Assistant token not set")
 
 


### PR DESCRIPTION
AppDaemon 4.5.0 migrated the configuration to use Pydantic models. These models use SecretStr for fields that contain secrets.

This seems to have caused two regressions, because of the automatic obfuscation that converts `str(SecretStr('abc'))` -> `'**********'`.

1. Password login became impossible, because HTTP.password came via model_dump(), which obfuscates secrets.
2. `x-ha-access` was no longer set correctly, because it did not unwrap `ha_key` before using it.

This is fixed by calling get_secret_value() on the SecretStr in both cases.

I have confirmed that password login works again after this fix.

Fixes #2462