### PR TITLE
fix production mode and scheduler race

### DIFF
--- a/appdaemon/app_management.py
+++ b/appdaemon/app_management.py
@@ -163,28 +163,24 @@ class AppManagement:
     def valid_apps(self) -> set[str]:
         return self.running_apps | self.loaded_globals
 
-    def start(self) -> None:
-        """Start the app management subsystem, which creates async tasks to
+    async def start(self) -> None:
+        """Start the app management subsystem.
 
-        * Initialize admin entities
-        * Call :meth:`~.check_app_updates`
-        * Fire an ``appd_started`` event in the ``global`` namespace.
-
+        This method:
+        * Initializes admin entities
+        * Initializes the dependency manager (INIT mode)
+        * Loads all apps (normal mode)
         """
         if self.AD.apps_enabled:
             self.logger.debug("Starting the app management subsystem")
-            self.AD.loop.create_task(self.init_admin_entities())
+            await self.init_admin_entities()
 
-            task = self.AD.loop.create_task(
-                self.check_app_updates(mode=UpdateMode.INIT),
-                name="check_app_updates",
-            )
-            task.add_done_callback(
-                lambda _: self.AD.loop.create_task(
-                    self.AD.events.process_event("global", {"event_type": "appd_started", "data": {}}),
-                    name="appd_started_event"
-                )
-            )
+            await self.check_app_updates(mode=UpdateMode.INIT)
+
+            self.logger.debug("Loading apps")
+            await self.check_app_updates()
+
+            self.logger.info("App initialization complete")
 
     async def stop(self) -> None:
         """Stop the app management subsystem and all the running apps.

--- a/appdaemon/appdaemon.py
+++ b/appdaemon/appdaemon.py
@@ -367,19 +367,14 @@ class AppDaemon:
         """Start AppDaemon, which also starts all the component subsystems like the scheduler, etc.
 
         - :meth:`ThreadAsync <appdaemon.thread_async.ThreadAsync.start>`
-        - :meth:`Scheduler <appdaemon.scheduler.Scheduler.start>`
         - :meth:`Utility <appdaemon.utility_loop.Utility.start>`
-        - :meth:`AppManagement <appdaemon.app_management.AppManagement.start>`
 
+        Note: The scheduler is started by the utility loop after plugins are ready.
         """
         self.logger.debug("Starting AppDaemon")
         self.thread_async.start()
-        self.sched.start()
         self.utility.start()
         self.state.start()
-
-        if self.apps_enabled:
-            self.app_management.start()
 
     async def stop(self) -> None:
         """Stop AppDaemon by calling the stop method of the subsystems.

--- a/appdaemon/utility_loop.py
+++ b/appdaemon/utility_loop.py
@@ -143,7 +143,8 @@ class Utility:
         * Starts the web server if configured
         * Waits for all plugins to initialize
         * Registers services
-        * Runs check_app_updates with UpdateMode.INIT if apps are enabled
+        * Starts the scheduler
+        * Initializes apps if apps are enabled
         """
         self.logger.debug("Starting utility loop")
 
@@ -158,7 +159,20 @@ class Utility:
         # Wait for all plugins to initialize
         await self.AD.plugins.wait_for_plugins()
 
+        if self.AD.stopping:
+            self.logger.debug("AppDaemon already stopping before starting utility loop")
+            return
+
         await self._register_services()
+
+        # Start the scheduler
+        self.AD.sched.start()
+
+        if self.AD.apps_enabled:
+            await self.AD.app_management.start()
+
+            # Fire APPD Started Event
+            await self.AD.events.process_event("global", {"event_type": "appd_started", "data": {}})
 
     async def loop(self):
         """Run the utility loop, which handles the following:

--- a/tests/functional/test_production_mode.py
+++ b/tests/functional/test_production_mode.py
@@ -1,0 +1,48 @@
+import os
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+from appdaemon.appdaemon import AppDaemon
+
+
+@pytest_asyncio.fixture(scope="function")
+async def ad_production(ad_obj: AppDaemon):
+    """AppDaemon fixture with production_mode enabled."""
+    ad_obj.config.production_mode = True
+    ad_obj.app_dir = ad_obj.config_dir / "apps/hello_world"
+
+    ad_obj.start()
+    yield ad_obj
+    await ad_obj.stop()
+
+
+@pytest.mark.ci
+@pytest.mark.functional
+@pytest.mark.asyncio(loop_scope="session")
+async def test_production_mode_loads_apps(ad_production: AppDaemon) -> None:
+    """Test that apps load correctly when production_mode is enabled."""
+    # Wait for initialization to complete
+    await ad_production.utility.app_update_event.wait()
+    # Check that the app loaded
+    assert "hello_world" in ad_production.app_management.objects
+
+
+@pytest.mark.ci
+@pytest.mark.functional
+@pytest.mark.asyncio(loop_scope="session")
+async def test_production_mode_no_reloading(ad_production: AppDaemon) -> None:
+    """Test that production mode doesn't reload apps when files change."""
+    # Wait for initialization to complete
+    await ad_production.utility.app_update_event.wait()
+
+    # Mock check_app_updates to track calls from now on
+    mock = AsyncMock(wraps=ad_production.app_management.check_app_updates)
+    ad_production.app_management.check_app_updates = mock
+
+    # Touch file and wait for utility loop
+    ad_production.utility.app_update_event.clear()
+    os.utime(ad_production.app_dir / "hello.py", None)
+    await ad_production.utility.app_update_event.wait()
+
+    assert not mock.called, "Should not reload in production mode"


### PR DESCRIPTION
## Problem

Commit 2239e58b61ae83bbfa2c61bab670e0f6ac488804 ("Merge branch 'context-managers'") from 4.5.12 caused regressions in app initialization.

- Apps would no longer load with `production_mode: true` because the async task races with initialization, and `check_app_updates()` is never called again.
- Even in debug mode, app initialization became non-deterministic.

The system would log "App initialization complete" but apps weren't actually loaded yet (or ever, in production mode).


## Root Cause

The old `app_management.start()` method used `loop.create_task()` to initialize apps asynchronously:

```python
def start(self):
    self.AD.loop.create_task(self.init_admin_entities())
    task = self.AD.loop.create_task(
        self.check_app_updates(mode=UpdateMode.INIT),
        name="check_app_updates",
    )
    task.add_done_callback(lambda _: ...)
```

This created a race where apps might not be loaded before the system continued. In production mode, where `check_app_updates()` is skipped in the utility loop, apps would never load if the task hadn't completed yet.


## Solution

`app_management.start()` is replaced with a synchronous version. Scheduler initialization and app loading are moved back to the end of `Utility._init_loop`.

Two regression tests are added to verify that production mode is once again functional.


<br/>

Fixes #2442
Fixes #2467