### PR TITLE
fix scheduler crash

### DIFF
--- a/appdaemon/scheduler.py
+++ b/appdaemon/scheduler.py
@@ -622,7 +622,10 @@ class Scheduler:
                             args = self.schedule.get(name, {}).get(uuid_, False)
                             if time_to_run and args:
                                 func = utils.unwrapped(args["callback"])
-                                self.logger.debug("Firing scheduled callback %s for '%s'", func.__name__, name)
+                                if func is not None:
+                                    self.logger.debug("Firing scheduled callback %s for '%s'", func.__name__, name)
+                                else:
+                                    self.logger.debug("Firing timeout/cancellation entry for '%s'", name)
                                 await self.exec_schedule(name, args, uuid_)
                         case _:
                             raise ValueError(f"Unknown entry format: {entry}")
@@ -748,7 +751,9 @@ class Scheduler:
                 schedule[name][str(entry)]["kwargs"] = ""
                 for kwarg in self.schedule[name][entry]["kwargs"]:
                     schedule[name][str(entry)]["kwargs"] = utils.get_kwargs(self.schedule[name][entry]["kwargs"])
-                if isinstance(self.schedule[name][entry]["callback"], functools.partial):
+                if self.schedule[name][entry]["callback"] is None:
+                    schedule[name][str(entry)]["callback"] = "cancel_callback"
+                elif isinstance(self.schedule[name][entry]["callback"], functools.partial):
                     schedule[name][str(entry)]["callback"] = self.schedule[name][entry]["callback"].func.__name__
                 else:
                     schedule[name][str(entry)]["callback"] = self.schedule[name][entry]["callback"].__name__


### PR DESCRIPTION
Commit 654000c33aebb73198dea5e84ef26f23067c4ee3 from v4.5.12 introduced a regression in the scheduler loop. As reported on Discord by xtalker:
> Looking for some insight into this prob that has come up after updating Hass and AD. recently.  I use AD for all automations and when this happens all AD automations are blocked.  I can't corollate this issue to anything in my AD scripts.  Restarting AD clears the problem (but it eventually happens again after several hours).
> 
> Any help appreciated!
> 
> In appdaemon.log, this error is reported almost every second:
```
2025-11-10 17:15:15.181077 WARNING AppDaemon: ------------------------------------------------------------
2025-11-10 17:15:15.182035 WARNING AppDaemon: Unexpected error in scheduler loop
2025-11-10 17:15:15.182830 WARNING AppDaemon: ------------------------------------------------------------
2025-11-10 17:15:15.187647 WARNING AppDaemon: Traceback (most recent call last):
  File "/usr/lib/python3.12/site-packages/appdaemon/scheduler.py", line 625, in loop
    self.logger.debug("Firing scheduled callback %s for '%s'", func.__name__, name)
                                                               ^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute '__name__'. Did you mean: '__ne__'?
```

The commit mentioned above introduced a debug logging statement in the scheduler loop that assumes all callbacks are non-None function objects. However, timeout/cancellation entries are legitimately None. These entries are created when callbacks have `timeout` parameters and are used to cancel other callbacks (state, event, or log callbacks) when they expire.

The bug manifests after several hours because timeout entries only trigger when their scheduled event arrives.

### The Fix

Added a None check before accessing the callback's `__name__` attribute:

```python
func = utils.unwrapped(args["callback"])
if func is not None:
    self.logger.debug("Firing scheduled callback %s for '%s'", func.__name__, name)
else:
    self.logger.debug("Firing timeout/cancellation entry for '%s'", name)
await self.exec_schedule(name, args, uuid_)
```

A similar fix was applied to the schedule display function to prevent the same error when viewing scheduled callbacks.