### PR TITLE
fix entity persistence

### DIFF
--- a/appdaemon/state.py
+++ b/appdaemon/state.py
@@ -879,7 +879,8 @@ class State:
             self.state[namespace].update(state)
         else:
             # first in case it had been created before, it should be deleted
-            await self.remove_namespace(namespace)
+            if isinstance(self.state.get(namespace), utils.PersistentDict):
+                await self.remove_persistent_namespace(namespace, self.state[namespace])
             self.state[namespace] = state
 
     def update_namespace_state(self, namespace: str | list[str], state: dict):


### PR DESCRIPTION
A user on the Discord (andarotajo) reported that the state of entities in persistent namespaces was not being preserved across AppDaemon restarts.

This is my understanding of the history:
- June 23rd: 4.5.11 is known good
- Oct 3rd: commit 587789a3 ("match/case statements") caused the db to no longer save
- Oct 12th: 4.5.12 is released, including the above commit
- Oct 16th: commit 9ee8853c ("fixed existence check") causes the db to save properly again
- Oct 25th: commit 229d0773 ("python 3.13 support") introduces the issue which causes the warning on startup about the entity not being found

I believe this PR should fix the most recent regression. I may add a proper test now that I understand which versions to compare with.