### PR TITLE
Fix HASS url building

### DIFF
--- a/appdaemon/models/config/plugin.py
+++ b/appdaemon/models/config/plugin.py
@@ -5,6 +5,7 @@ from typing import Annotated, Any, Literal
 
 from pydantic import AnyHttpUrl, BaseModel, BeforeValidator, Field, SecretBytes, SecretStr, field_validator, model_validator
 from typing_extensions import deprecated
+from yarl import URL
 
 
 from .common import CoercedPath, ParsedTimedelta
@@ -86,7 +87,7 @@ class StartupConditions(BaseModel):
 
 
 class HASSConfig(PluginConfig, extra="forbid"):
-    ha_url: AnyHttpUrl = Field(default="http://supervisor/core", validate_default=True) # pyright: ignore[reportAssignmentType]
+    ha_url: URL = Field(default="http://supervisor/core", validate_default=True)
     token: SecretStr = Field(default_factory=lambda: SecretStr(os.environ.get("SUPERVISOR_TOKEN"))) # pyright: ignore[reportArgumentType]
     ha_key: Annotated[SecretStr, deprecated("'ha_key' is deprecated. Please use long lived tokens instead")] | None = None
     appdaemon_startup_conditions: StartupConditions | None = None
@@ -108,6 +109,11 @@ class HASSConfig(PluginConfig, extra="forbid"):
     config_sleep_time: ParsedTimedelta = timedelta(seconds=60)
     """The sleep time in the background task that updates the config metadata every once in a while"""
 
+    @field_validator("ha_url", mode="before")
+    @classmethod
+    def validate_ha_url(cls, v: Any) -> URL:
+        return URL(str(AnyHttpUrl(v)).rstrip('/') + '/')
+
     @model_validator(mode="after")
     def custom_validator(self):
         if self.token.get_secret_value() is None:
@@ -117,15 +123,15 @@ class HASSConfig(PluginConfig, extra="forbid"):
         return self
 
     @property
-    def websocket_url(self) -> str:
-        return f"{self.ha_url!s}/api/websocket"
+    def websocket_url(self) -> URL:
+        return self.ha_url / "api/websocket"
 
     @property
-    def states_api(self) -> str:
-        return f"{self.ha_url!s}/api/states"
+    def states_api(self) -> URL:
+        return self.ha_url / "api/states"
 
-    def get_entity_api(self, entity_id: str) -> str:
-        return f"{self.states_api}/{entity_id}"
+    def get_entity_api(self, entity_id: str) -> URL:
+        return self.states_api / entity_id
 
     @property
     def auth_json(self) -> dict:

--- a/appdaemon/models/config/plugin.py
+++ b/appdaemon/models/config/plugin.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 from ssl import _SSLMethod
 from typing import Annotated, Any, Literal
 
-from pydantic import AnyHttpUrl, BaseModel, BeforeValidator, Field, SecretBytes, SecretStr, field_validator, model_validator
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, PlainSerializer, SecretBytes, SecretStr, field_validator, model_validator
 from typing_extensions import deprecated
 from yarl import URL
 
@@ -86,7 +86,11 @@ class StartupConditions(BaseModel):
 
 
 class HASSConfig(PluginConfig, extra="forbid"):
-    ha_url: Annotated[str, BeforeValidator(lambda u: str(AnyHttpUrl(u)))] = Field(default="http://supervisor/core", validate_default=True)
+    ha_url: Annotated[
+        URL,
+        BeforeValidator(URL),
+        PlainSerializer(str),
+    ] = Field(default="http://supervisor/core", validate_default=True) # pyright: ignore[reportAssignmentType]
     token: SecretStr = Field(default_factory=lambda: SecretStr(os.environ.get("SUPERVISOR_TOKEN"))) # pyright: ignore[reportArgumentType]
     ha_key: Annotated[SecretStr, deprecated("'ha_key' is deprecated. Please use long lived tokens instead")] | None = None
     appdaemon_startup_conditions: StartupConditions | None = None
@@ -108,6 +112,8 @@ class HASSConfig(PluginConfig, extra="forbid"):
     config_sleep_time: ParsedTimedelta = timedelta(seconds=60)
     """The sleep time in the background task that updates the config metadata every once in a while"""
 
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     @model_validator(mode="after")
     def custom_validator(self):
         if self.token.get_secret_value() is None:
@@ -118,7 +124,7 @@ class HASSConfig(PluginConfig, extra="forbid"):
 
     @property
     def websocket_url(self) -> URL:
-        return URL(self.ha_url) / "api/websocket"
+        return self.ha_url / "api/websocket"
 
     @property
     def auth_json(self) -> dict:

--- a/appdaemon/models/config/plugin.py
+++ b/appdaemon/models/config/plugin.py
@@ -3,29 +3,11 @@ from datetime import timedelta
 from ssl import _SSLMethod
 from typing import Annotated, Any, Literal
 
-from pydantic import (
-    AnyHttpUrl,
-    BaseModel,
-    BeforeValidator,
-    Field,
-    PlainSerializer,
-    SecretBytes,
-    SecretStr,
-    field_validator,
-    model_validator,
-)
+from pydantic import AnyHttpUrl, BaseModel, BeforeValidator, Field, SecretBytes, SecretStr, field_validator, model_validator
 from typing_extensions import deprecated
 from yarl import URL
 
 from .common import CoercedPath, ParsedTimedelta
-
-
-def _validate_url(v: Any) -> URL:
-    """Validate and convert to yarl.URL using Pydantic's AnyHttpUrl validator."""
-    return URL(str(AnyHttpUrl(v)).rstrip('/') + '/')
-
-
-ValidatedURL = Annotated[URL, BeforeValidator(_validate_url), PlainSerializer(str, return_type=str)]
 
 
 class PluginConfig(BaseModel, extra="allow"):
@@ -104,7 +86,7 @@ class StartupConditions(BaseModel):
 
 
 class HASSConfig(PluginConfig, extra="forbid"):
-    ha_url: ValidatedURL = Field(default="http://supervisor/core", validate_default=True)
+    ha_url: AnyHttpUrl = Field(default="http://supervisor/core", validate_default=True)
     token: SecretStr = Field(default_factory=lambda: SecretStr(os.environ.get("SUPERVISOR_TOKEN"))) # pyright: ignore[reportArgumentType]
     ha_key: Annotated[SecretStr, deprecated("'ha_key' is deprecated. Please use long lived tokens instead")] | None = None
     appdaemon_startup_conditions: StartupConditions | None = None
@@ -136,11 +118,11 @@ class HASSConfig(PluginConfig, extra="forbid"):
 
     @property
     def websocket_url(self) -> URL:
-        return self.ha_url / "api/websocket"
+        return self.ha_url_yarl / "api/websocket"
 
     @property
     def states_api(self) -> URL:
-        return self.ha_url / "api/states"
+        return self.ha_url_yarl / "api/states"
 
     def get_entity_api(self, entity_id: str) -> URL:
         return self.states_api / entity_id
@@ -160,6 +142,10 @@ class HASSConfig(PluginConfig, extra="forbid"):
         elif self.ha_key is not None:
             return {"x-ha-access": self.ha_key}
         raise ValueError("Home Assistant token not set")
+
+    @property
+    def ha_url_yarl(self) -> URL:
+        return URL(str(self.ha_url).rstrip('/') + '/')
 
 
 class MQTTConfig(PluginConfig):

--- a/appdaemon/models/config/plugin.py
+++ b/appdaemon/models/config/plugin.py
@@ -121,13 +121,6 @@ class HASSConfig(PluginConfig, extra="forbid"):
         return self.ha_url_yarl / "api/websocket"
 
     @property
-    def states_api(self) -> URL:
-        return self.ha_url_yarl / "api/states"
-
-    def get_entity_api(self, entity_id: str) -> URL:
-        return self.states_api / entity_id
-
-    @property
     def auth_json(self) -> dict:
         if self.token is not None:
             return {"type": "auth", "access_token": self.token.get_secret_value()}

--- a/appdaemon/models/config/plugin.py
+++ b/appdaemon/models/config/plugin.py
@@ -86,7 +86,7 @@ class StartupConditions(BaseModel):
 
 
 class HASSConfig(PluginConfig, extra="forbid"):
-    ha_url: AnyHttpUrl = Field(default="http://supervisor/core", validate_default=True)
+    ha_url: Annotated[str, BeforeValidator(lambda u: str(AnyHttpUrl(u)))] = Field(default="http://supervisor/core", validate_default=True)
     token: SecretStr = Field(default_factory=lambda: SecretStr(os.environ.get("SUPERVISOR_TOKEN"))) # pyright: ignore[reportArgumentType]
     ha_key: Annotated[SecretStr, deprecated("'ha_key' is deprecated. Please use long lived tokens instead")] | None = None
     appdaemon_startup_conditions: StartupConditions | None = None
@@ -118,7 +118,7 @@ class HASSConfig(PluginConfig, extra="forbid"):
 
     @property
     def websocket_url(self) -> URL:
-        return self.ha_url_yarl / "api/websocket"
+        return URL(self.ha_url) / "api/websocket"
 
     @property
     def auth_json(self) -> dict:
@@ -135,10 +135,6 @@ class HASSConfig(PluginConfig, extra="forbid"):
         elif self.ha_key is not None:
             return {"x-ha-access": self.ha_key}
         raise ValueError("Home Assistant token not set")
-
-    @property
-    def ha_url_yarl(self) -> URL:
-        return URL(str(self.ha_url).rstrip('/') + '/')
 
 
 class MQTTConfig(PluginConfig):

--- a/appdaemon/models/config/plugin.py
+++ b/appdaemon/models/config/plugin.py
@@ -3,12 +3,29 @@ from datetime import timedelta
 from ssl import _SSLMethod
 from typing import Annotated, Any, Literal
 
-from pydantic import AnyHttpUrl, BaseModel, BeforeValidator, Field, SecretBytes, SecretStr, field_validator, model_validator
+from pydantic import (
+    AnyHttpUrl,
+    BaseModel,
+    BeforeValidator,
+    Field,
+    PlainSerializer,
+    SecretBytes,
+    SecretStr,
+    field_validator,
+    model_validator,
+)
 from typing_extensions import deprecated
 from yarl import URL
 
-
 from .common import CoercedPath, ParsedTimedelta
+
+
+def _validate_url(v: Any) -> URL:
+    """Validate and convert to yarl.URL using Pydantic's AnyHttpUrl validator."""
+    return URL(str(AnyHttpUrl(v)).rstrip('/') + '/')
+
+
+ValidatedURL = Annotated[URL, BeforeValidator(_validate_url), PlainSerializer(str, return_type=str)]
 
 
 class PluginConfig(BaseModel, extra="allow"):
@@ -87,7 +104,7 @@ class StartupConditions(BaseModel):
 
 
 class HASSConfig(PluginConfig, extra="forbid"):
-    ha_url: URL = Field(default="http://supervisor/core", validate_default=True)
+    ha_url: ValidatedURL = Field(default="http://supervisor/core", validate_default=True)
     token: SecretStr = Field(default_factory=lambda: SecretStr(os.environ.get("SUPERVISOR_TOKEN"))) # pyright: ignore[reportArgumentType]
     ha_key: Annotated[SecretStr, deprecated("'ha_key' is deprecated. Please use long lived tokens instead")] | None = None
     appdaemon_startup_conditions: StartupConditions | None = None
@@ -108,11 +125,6 @@ class HASSConfig(PluginConfig, extra="forbid"):
     """The sleep time in the background task that updates the internal list of available services every once in a while"""
     config_sleep_time: ParsedTimedelta = timedelta(seconds=60)
     """The sleep time in the background task that updates the config metadata every once in a while"""
-
-    @field_validator("ha_url", mode="before")
-    @classmethod
-    def validate_ha_url(cls, v: Any) -> URL:
-        return URL(str(AnyHttpUrl(v)).rstrip('/') + '/')
 
     @model_validator(mode="after")
     def custom_validator(self):

--- a/appdaemon/models/config/plugin.py
+++ b/appdaemon/models/config/plugin.py
@@ -118,11 +118,11 @@ class HASSConfig(PluginConfig, extra="forbid"):
 
     @property
     def websocket_url(self) -> str:
-        return f"{self.ha_url!s}api/websocket"
+        return f"{self.ha_url!s}/api/websocket"
 
     @property
     def states_api(self) -> str:
-        return f"{self.ha_url!s}api/states"
+        return f"{self.ha_url!s}/api/states"
 
     def get_entity_api(self, entity_id: str) -> str:
         return f"{self.states_api}/{entity_id}"

--- a/appdaemon/plugins/hass/hassplugin.py
+++ b/appdaemon/plugins/hass/hassplugin.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from time import perf_counter
 from typing import Any, Literal, Optional
+from yarl import URL
 
 import aiohttp
 from aiohttp import ClientResponse, ClientResponseError, RequestInfo, WSMsgType, WebSocketError
@@ -441,7 +442,7 @@ class HassPlugin(PluginBase):
     async def http_method(
         self,
         method: Literal["get", "post", "delete"],
-        endpoint: str,
+        endpoint: str | URL,
         timeout: str | int | float | timedelta | None = 10,
         **kwargs: Any,
     ) -> str | dict[str, Any] | list[Any] | aiohttp.ClientResponseError | None:
@@ -456,11 +457,11 @@ class HassPlugin(PluginBase):
                 appropriate.
         """
         kwargs = utils.clean_http_kwargs(kwargs)
-        url = utils.make_endpoint(f"{self.config.ha_url!s}", endpoint)
+        url = self.config.ha_url.join(URL(endpoint))
 
         try:
             self.update_perf(
-                bytes_sent=len(url) + len(json.dumps(kwargs).encode("utf-8")),
+                bytes_sent=len(str(url)) + len(json.dumps(kwargs).encode("utf-8")),
                 requests_sent=1,
             )
 

--- a/appdaemon/plugins/hass/hassplugin.py
+++ b/appdaemon/plugins/hass/hassplugin.py
@@ -457,7 +457,7 @@ class HassPlugin(PluginBase):
                 appropriate.
         """
         kwargs = utils.clean_http_kwargs(kwargs)
-        url = self.config.ha_url.join(URL(endpoint))
+        url = self.config.ha_url_yarl.join(URL(endpoint))
 
         try:
             self.update_perf(

--- a/appdaemon/plugins/hass/hassplugin.py
+++ b/appdaemon/plugins/hass/hassplugin.py
@@ -16,6 +16,7 @@ from typing import Any, Literal, Optional
 import aiohttp
 from aiohttp import ClientResponse, ClientResponseError, RequestInfo, WSMsgType, WebSocketError
 from pydantic import BaseModel
+from yarl import URL
 
 import appdaemon.utils as utils
 from appdaemon.appdaemon import AppDaemon
@@ -456,7 +457,7 @@ class HassPlugin(PluginBase):
                 appropriate.
         """
         kwargs = utils.clean_http_kwargs(kwargs)
-        url = self.config.ha_url_yarl / endpoint.lstrip("/")
+        url = URL(self.config.ha_url) / endpoint.lstrip("/")
 
         try:
             self.update_perf(

--- a/appdaemon/plugins/hass/hassplugin.py
+++ b/appdaemon/plugins/hass/hassplugin.py
@@ -12,7 +12,6 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from time import perf_counter
 from typing import Any, Literal, Optional
-from yarl import URL
 
 import aiohttp
 from aiohttp import ClientResponse, ClientResponseError, RequestInfo, WSMsgType, WebSocketError
@@ -442,7 +441,7 @@ class HassPlugin(PluginBase):
     async def http_method(
         self,
         method: Literal["get", "post", "delete"],
-        endpoint: str | URL,
+        endpoint: str,
         timeout: str | int | float | timedelta | None = 10,
         **kwargs: Any,
     ) -> str | dict[str, Any] | list[Any] | aiohttp.ClientResponseError | None:
@@ -457,7 +456,7 @@ class HassPlugin(PluginBase):
                 appropriate.
         """
         kwargs = utils.clean_http_kwargs(kwargs)
-        url = self.config.ha_url_yarl.join(URL(endpoint))
+        url = self.config.ha_url_yarl / endpoint.lstrip("/")
 
         try:
             self.update_perf(
@@ -885,8 +884,7 @@ class HassPlugin(PluginBase):
 
         @utils.warning_decorator(error_text=f"Error setting state for {entity_id}")
         async def safe_set_state(self: "HassPlugin"):
-            api_url = self.config.get_entity_api(entity_id)
-            return await self.http_method("post", api_url, state=state, attributes=attributes)
+            return await self.http_method("post", f"/api/states/{entity_id}", state=state, attributes=attributes)
 
         return await safe_set_state(self)
 

--- a/appdaemon/plugins/hass/hassplugin.py
+++ b/appdaemon/plugins/hass/hassplugin.py
@@ -14,9 +14,8 @@ from time import perf_counter
 from typing import Any, Literal, Optional
 
 import aiohttp
-from aiohttp import ClientResponse, ClientResponseError, RequestInfo, WSMsgType, WebSocketError
+from aiohttp import ClientResponse, ClientResponseError, RequestInfo, WebSocketError, WSMsgType
 from pydantic import BaseModel
-from yarl import URL
 
 import appdaemon.utils as utils
 from appdaemon.appdaemon import AppDaemon
@@ -457,7 +456,7 @@ class HassPlugin(PluginBase):
                 appropriate.
         """
         kwargs = utils.clean_http_kwargs(kwargs)
-        url = URL(self.config.ha_url) / endpoint.lstrip("/")
+        url = self.config.ha_url / endpoint.lstrip("/")
 
         try:
             self.update_perf(

--- a/appdaemon/utils.py
+++ b/appdaemon/utils.py
@@ -1167,15 +1167,6 @@ def clean_http_kwargs(val: Any) -> Any:
     return pruned
 
 
-def make_endpoint(base: str, endpoint: str) -> str:
-    """Formats a URL appropriately with slashes"""
-    if not endpoint.startswith(base):
-        result = f"{base}/{endpoint.strip('/')}"
-    else:
-        result = endpoint
-    return result.strip("/")
-
-
 def unwrapped(func: Callable) -> Callable:
     while hasattr(func, "__wrapped__"):
         func = func.__wrapped__


### PR DESCRIPTION
Commit dbe57fe04692401b62f7c8368269f00b22ba2bdd ("now possible to set the Hass token with the SUPERVISOR_TOKEN env var") removed a slash in the URL built by the websocket_url and states_api, which is actually needed. Otherwise you get this with the default URL:
```
2025-11-16 07:00:51.343666 ERROR HASS: 403, message='Invalid response status', url='http://supervisor/coreapi/websocket'
```

note the `coreapi`, which is the concatenation of `core` from the default URL and `api` from the subpath.