### PR TITLE
fix set_state error handling

### DIFF
--- a/appdaemon/plugins/hass/hassplugin.py
+++ b/appdaemon/plugins/hass/hassplugin.py
@@ -881,7 +881,7 @@ class HassPlugin(PluginBase):
         entity_id: str,
         state: Any | None = None,
         attributes: Any | None = None,
-    ):
+    ) -> dict[str, Any] | None:
         self.logger.debug("set_plugin_state() %s %s %s %s", namespace, entity_id, state, attributes)
 
         # if we get a request for not our namespace something has gone very wrong
@@ -892,7 +892,15 @@ class HassPlugin(PluginBase):
             api_url = self.config.get_entity_api(entity_id)
             return await self.http_method("post", api_url, state=state, attributes=attributes)
 
-        return await safe_set_state(self)
+        resp = await safe_set_state(self)
+        match resp:
+            case ClientResponseError(message=str(msg)):
+                self.logger.error("Error setting state: %s", msg)
+                return None
+            case dict():
+                return resp
+            case _:
+                return None
 
     @utils.warning_decorator(error_text="Unexpected error getting state")
     async def get_plugin_state(

--- a/appdaemon/state.py
+++ b/appdaemon/state.py
@@ -3,7 +3,7 @@ import sys
 import threading
 import traceback
 import uuid
-from collections.abc import Mapping
+from collections.abc import Awaitable, Callable, Mapping
 from copy import copy, deepcopy
 from datetime import timedelta
 from enum import Enum
@@ -836,21 +836,25 @@ class State:
 
         plugin = self.AD.plugins.get_plugin_object(namespace)
 
-        if set_plugin_state := getattr(plugin, "set_plugin_state", False):
+        plugin_handled = False
+        set_plugin_state: Callable[..., Awaitable[dict[str, Any] | None]] | None
+        if (set_plugin_state := getattr(plugin, "set_plugin_state", None)) is not None:
             # We assume that the state change will come back to us via the plugin
             self.logger.debug("sending event to plugin")
 
-            result = await set_plugin_state( # pyright: ignore[reportCallIssue]
+            result = await set_plugin_state(
                 namespace,
                 entity,
                 state=new_state["state"],
-                attributes=new_state["attributes"]
-            )  # fmt: skip
+                attributes=new_state["attributes"],
+            )
             if result is not None:
                 if "entity_id" in result:
                     result.pop("entity_id")
                 self.state[namespace][entity] = self.parse_state(namespace, entity, **result)
-        else:
+                plugin_handled = True
+
+        if not plugin_handled:
             # Set the state locally
             self.state[namespace][entity] = new_state
             # Fire the event locally

--- a/appdaemon/state.py
+++ b/appdaemon/state.py
@@ -9,7 +9,7 @@ from datetime import timedelta
 from enum import Enum
 from logging import Logger
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Awaitable, List, Literal, Optional, Protocol, Set, overload
+from typing import TYPE_CHECKING, Any, Literal, Optional, Protocol, overload
 
 from . import exceptions as ade
 from . import utils
@@ -51,7 +51,7 @@ class State:
     name: str = "_state"
     state: dict[str, dict[str, Any] | utils.PersistentDict]
 
-    app_added_namespaces: Set[str]
+    app_added_namespaces: set[str]
 
     def __init__(self, ad: "AppDaemon"):
         self.AD = ad
@@ -234,7 +234,7 @@ class State:
                         self.logger.error('Error removing namespace file %s: %s', ns_file.name, e)
                         continue
 
-    def list_namespaces(self) -> List[str]:
+    def list_namespaces(self) -> list[str]:
         return list(self.state.keys())
 
     def list_namespace_entities(self, namespace: str) -> list[str]:


### PR DESCRIPTION
The bug reported is that HASS set_plugin_state can return an error which wasn't handled before, resulting in a TypeError, as reported by both TimW and xtalker (Bob) on Discord:

```
File "/conf/apps/solar/power_generation_analysis_v3.py", line 466, in update_analysis_sensors
  self.set_state(sensor_name, state=seconds, attributes=attributes, namespace="default")
File "/usr/local/lib/python3.12/site-packages/appdaemon/utils.py", line 289, in wrapper
  return run_coroutine_threadsafe(self, coro, timeout=timeout)
File "/usr/local/lib/python3.12/site-packages/appdaemon/utils.py", line 615, in run_coroutine_threadsafe
  return future.result(timeout.total_seconds())
File "/usr/local/lib/python3.12/concurrent/futures/_base.py", line 456, in result
  return self.__get_result()
File "/usr/local/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
  raise self._exception
File "/usr/local/lib/python3.12/site-packages/appdaemon/adapi.py", line 1789, in set_state
  return await self.AD.state.set_state(
File "/usr/local/lib/python3.12/site-packages/appdaemon/state.py", line 793, in set_state
  if "entity_id" in result:
     ^^^^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'ClientResponseError' is not iterable
```

This PR adds error handling in set_plugin_state consistent with get_plugin_state to fix that error. It also adds fallback to local handling on error, instead of doing nothing. (Let me know if you think that makes sense.)