### PR TITLE
better support for mixing yaml and toml apps

### DIFF
--- a/appdaemon/__main__.py
+++ b/appdaemon/__main__.py
@@ -296,7 +296,6 @@ class ADMain:
             self.dep_manager = DependencyManager.from_app_directory(
                 self.model.appdaemon.app_dir,
                 exclude=self.model.appdaemon.exclude_dirs,
-                config_suffix=self.model.appdaemon.ext,
             )
 
         except Exception as e:

--- a/appdaemon/app_management.py
+++ b/appdaemon/app_management.py
@@ -21,7 +21,6 @@ from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
 from pydantic import ValidationError
 
-
 from appdaemon.dependency import DependencyResolutionFail, find_all_dependents, get_full_module_name
 from appdaemon.dependency_manager import DependencyManager
 from appdaemon.models.config import AllAppConfig, AppConfig, GlobalModule
@@ -33,9 +32,9 @@ from . import utils
 from .models.internal.app_management import LoadingActions, ManagedObject, UpdateActions, UpdateMode
 
 if TYPE_CHECKING:
-    from .appdaemon import AppDaemon
-    from .adbase import ADBase
     from .adapi import ADAPI
+    from .adbase import ADBase
+    from .appdaemon import AppDaemon
     from .plugin_management import PluginBase
 
 T = TypeVar("T")
@@ -87,7 +86,6 @@ class AppManagement:
 
     def __init__(self, ad: "AppDaemon"):
         self.AD = ad
-        self.ext = self.AD.config.ext
         self.logger = ad.logging.get_child(self.name)
         self.error = ad.logging.get_error()
         self.diag = ad.logging.get_diag()
@@ -1047,8 +1045,8 @@ class AppManagement:
         return set(
             utils.recursive_get_files(
                 base=self.AD.app_dir.resolve(),
-                suffix=self.ext,
-                exclude=set(self.AD.exclude_dirs),
+                suffix={".yaml", ".toml"},
+                exclude=set(self.AD.exclude_dirs) | {"ruff.toml", "pyproject.toml", "secrets.yaml"},
             )
         )
 
@@ -1323,7 +1321,7 @@ class AppManagement:
             return False
 
         app_directory: Path = self.AD.app_dir / kwargs.pop("app_dir", "ad_apps")
-        app_file: Path = app_directory / kwargs.pop("app_file", f"{app}{self.ext}")
+        app_file: Path = app_directory / kwargs.pop("app_file", f"{app}{self.AD.config.ext}")
         app_directory = app_file.parent  # in case the given app_file is multi level
 
         try:

--- a/appdaemon/dependency_manager.py
+++ b/appdaemon/dependency_manager.py
@@ -1,7 +1,6 @@
 from abc import ABC
 from copy import deepcopy
 from dataclasses import InitVar, dataclass, field
-from functools import partial
 from pathlib import Path
 from typing import Iterable
 
@@ -16,7 +15,7 @@ class Dependencies(ABC):
     """Wraps an instance of ``FileCheck`` with a corresponding set of dependency graphs."""
 
     files: FileCheck = field(repr=False)
-    ext: str = field(init=False)  # this has to be defined by the children classes
+    ext: str | set[str] = field(init=False)  # this has to be defined by the children classes
     dep_graph: dict[str, set[str]] = field(init=False)
     rev_graph: dict[str, set[str]] = field(init=False)
     bad_files: set[tuple[Path, float]] = field(default_factory=set, init=False)
@@ -39,7 +38,13 @@ class Dependencies(ABC):
 
     @classmethod
     def from_path(cls, path: Path):
-        return cls.from_paths(path.rglob(f"*{cls.ext}"))
+        return cls.from_paths(
+            utils.recursive_get_files(
+                base=path,
+                suffix={".yaml", ".toml"},
+                exclude={"ruff.toml", "pyproject.toml", "secrets.yaml"},
+            )
+        )
 
     @classmethod
     def from_paths(cls, paths: Iterable[Path]):
@@ -90,7 +95,6 @@ class PythonDeps(Dependencies):
 @dataclass
 class AppDeps(Dependencies):
     app_config: AllAppConfig = field(init=False, repr=False)
-    ext: str = ".yaml"
 
     def __post_init__(self):
         self.app_config = AllAppConfig.from_config_files(self.files)
@@ -157,7 +161,6 @@ class DependencyManager:
         cls,
         app_dir: Path,
         exclude: str | Iterable[str] | None = None,
-        config_suffix: str = ".yaml",
     ) -> "DependencyManager":
         """Creates a new instance of the dependency manager from the given app directory"""
         match exclude:
@@ -168,12 +171,14 @@ class DependencyManager:
             case _:
                 exclude_set = set(exclude)
 
-        get_files = partial(utils.recursive_get_files, base=app_dir, exclude=exclude_set)
         return cls(
-            # python_files=get_files(suffix=".py"),
             python_files=list(),
-            config_files=get_files(suffix=config_suffix)
-        )  # fmt: skip
+            config_files=utils.recursive_get_files(
+                base=app_dir,
+                suffix={".yaml", ".toml"},
+                exclude=exclude_set,
+            )
+        )
 
     @property
     def app_config_files(self) -> set[Path]:

--- a/appdaemon/utils.py
+++ b/appdaemon/utils.py
@@ -1217,7 +1217,7 @@ def deprecation_warnings(model: BaseModel, logger: Logger):
                 deprecation_warnings(attr, logger)
 
 
-def recursive_get_files(base: Path, suffix: str, exclude: set[str] | None = None) -> Generator[Path, None, None]:
+def recursive_get_files(base: Path, suffix: str | set[str], exclude: set[str] | None = None) -> Generator[Path, None, None]:
     """Recursively generate file paths.
 
     Args:
@@ -1228,11 +1228,12 @@ def recursive_get_files(base: Path, suffix: str, exclude: set[str] | None = None
     Yields:
         Path objects to files that have the matching extension and are readable.
     """
+    suffix = {suffix} if isinstance(suffix, str) else suffix
     exclude = set() if exclude is None else exclude
     for item in base.iterdir():
         if item.name.startswith(".") or (exclude is None or item.name in exclude):
             continue
-        elif item.is_file() and item.suffix == suffix and os.access(item, os.R_OK):
+        elif item.is_file() and item.suffix in suffix and os.access(item, os.R_OK):
             yield item
         elif item.is_dir() and os.access(item, os.R_OK):
             yield from recursive_get_files(item, suffix, exclude)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,13 +6,12 @@ from datetime import datetime
 
 import pytest
 import pytest_asyncio
+from appdaemon import AppDaemon
 from appdaemon.dependency_manager import DependencyManager
 from appdaemon.logging import Logging
 from appdaemon.models.config.app import AppConfig
 from appdaemon.models.config.appdaemon import AppDaemonConfig
 from appdaemon.utils import format_timedelta, recursive_get_files
-
-from appdaemon import AppDaemon
 
 logger = logging.getLogger("AppDaemon._test")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,12 +6,13 @@ from datetime import datetime
 
 import pytest
 import pytest_asyncio
-from appdaemon import AppDaemon
 from appdaemon.dependency_manager import DependencyManager
 from appdaemon.logging import Logging
 from appdaemon.models.config.app import AppConfig
 from appdaemon.models.config.appdaemon import AppDaemonConfig
 from appdaemon.utils import format_timedelta, recursive_get_files
+
+from appdaemon import AppDaemon
 
 logger = logging.getLogger("AppDaemon._test")
 
@@ -51,7 +52,7 @@ async def ad(ad_obj: AppDaemon, running_loop: asyncio.BaseEventLoop) -> AsyncGen
     # logger.info(f"Passed loop: {hex(id(running_loop))}")
     assert running_loop == asyncio.get_running_loop(), "The running loop should match the one passed in"
     ad = ad_obj
-    config_files = list(recursive_get_files(base=ad.app_dir, suffix=ad.config.ext))
+    config_files = list(recursive_get_files(base=ad.app_dir, suffix={'.yaml', '.toml'}))
     ad.app_management.dependency_manager = DependencyManager(python_files=list(), config_files=config_files)
 
     for cfg in ad.app_management.app_config.root.values():


### PR DESCRIPTION
There isn't really a reason to distinguish between apps defined in yaml vs toml files because the appropriate loader gets invoked either way be `read_config`

Should fix #2488