### PR TITLE
parse: fix time zone handling in scheduler time parsing

### DIFF
--- a/appdaemon/parse.py
+++ b/appdaemon/parse.py
@@ -1,12 +1,55 @@
 import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from datetime import datetime, time, timedelta
+from datetime import datetime, time, timedelta, tzinfo
 from functools import partial
 from typing import ClassVar, Literal
+from zoneinfo import ZoneInfo
 
 import astral
+import pytz
 from astral.location import Location
+
+
+def normalize_tz(tz: tzinfo) -> tzinfo:
+    """Convert pytz timezone to ZoneInfo for clean stdlib-compatible handling.
+
+    pytz timezones don't behave like normal tzinfo implementations and require
+    special localize()/normalize() calls. By converting to ZoneInfo at the boundary,
+    we can use standard replace(tzinfo=...) and astimezone() everywhere else.
+
+    Args:
+        tz: Any tzinfo object (pytz, ZoneInfo, or fixed-offset)
+
+    Returns:
+        ZoneInfo if input was pytz with an IANA zone name, otherwise unchanged
+    """
+    if isinstance(tz, pytz.tzinfo.BaseTzInfo) and tz.zone is not None:
+        return ZoneInfo(tz.zone)
+    return tz
+
+
+def localize_naive(naive_dt: datetime, tz: tzinfo) -> datetime:
+    """Interpret a naive datetime as wall-clock time in the given timezone.
+
+    This normalizes pytz timezones to ZoneInfo first, so we can use standard
+    replace(tzinfo=...) semantics instead of pytz's localize().
+
+    Args:
+        naive_dt: A naive datetime (no tzinfo)
+        tz: The timezone to interpret the datetime in
+
+    Returns:
+        A timezone-aware datetime
+
+    Raises:
+        ValueError: If naive_dt already has tzinfo
+    """
+    if naive_dt.tzinfo is not None:
+        raise ValueError("expected naive datetime")
+    tz = normalize_tz(tz)
+    return naive_dt.replace(tzinfo=tz)
+
 
 CONVERTERS = {
     "hour": lambda v: timedelta(hours=v),
@@ -267,14 +310,16 @@ def resolve_time_str(
             else:
                 raise ValueError(f"Invalid time string: {input_string}")
 
+    tz = normalize_tz(now.tzinfo)
+
     offset = timedelta()
     match _parse(time_str):
         case time() as parsed_time:
-            result = datetime.combine(
+            naive_dt = datetime.combine(
                 (now + timedelta(days=days_offset)).date(),
                 parsed_time,
-                tzinfo=now.tzinfo
             )
+            result = localize_naive(naive_dt, tz)
         case datetime() as result:
             pass
         case Now(offset=offset):
@@ -338,14 +383,16 @@ def parse_datetime(
 
     assert isinstance(now, datetime) and now.tzinfo is not None, "Now must be a timezone-aware datetime"
 
+    tz = normalize_tz(now.tzinfo)
+
     offset = timedelta()
     match input_:
         case time() as input_time:
-            result = datetime.combine(
+            naive_dt = datetime.combine(
                 (now + timedelta(days=days_offset)).date(),
                 input_time,
-                tzinfo=now.tzinfo
             )
+            result = localize_naive(naive_dt, tz)
         case datetime() as result:
             result += timedelta(days=days_offset)
         case str() as time_str:
@@ -364,10 +411,9 @@ def parse_datetime(
 
     # Make the timezones match for the comparison below
     if result.tzinfo is None:
-        # Just adds the timezone without changing the time values
-        result = result.replace(tzinfo=now.tzinfo)
+        result = localize_naive(result, tz)
     else:
-        result = result.astimezone(now.tzinfo)
+        result = result.astimezone(tz)
 
     # The the days offset is negative, the result can't be forced to today, so set today to False
     if days_offset < 0:


### PR DESCRIPTION
### Problem

Users reported that `run_daily()` and other scheduler functions were scheduling callbacks at incorrect times, sometimes with unexpected offsets from the expected time. This regression was introduced after v4.4.2.

**Example from issue:**
```python
run = datetime.time(8, 0, 0)
self.run_daily(self.run_daily_c, run, val='on')
```
Expected execution: `08:00:00`  
Actual execution: `09:07:00`

### What Caused the Regression

In v4.4.2, the code correctly handled pytz timezones:

```python
# Old approach (correct)
event = datetime.combine(today, when)          # 1. Create NAIVE datetime
aware_event = self.AD.sched.convert_naive(event)  # 2. Localize with tz.localize()
```

The `convert_naive()` method properly used `self.AD.tz.localize(dt)`, which is the required pattern for pytz timezones to correctly determine the UTC offset based on DST for that specific date.

When the time parsing was refactored into `parse.py`, this pattern was replaced with:

```python
# New approach (broken)
result = datetime.combine(date, parsed_time, tzinfo=now.tzinfo)
```

This is **incorrect for pytz timezones**. Unlike standard `tzinfo` implementations, pytz timezones are stateful and require the `localize()` method to properly determine the UTC offset. When you pass a pytz timezone directly to `datetime.combine()` or use `dt.replace(tzinfo=...)`, pytz may apply an incorrect default offset that doesn't account for DST on that specific date.

### Solution

Instead of reverting to the old `localize()` pattern (which is pytz-specific and non-standard), we normalize pytz timezones to `ZoneInfo` (PEP 615) at the boundary:

1. **`normalize_tz(tz)`** - Converts pytz timezones to their equivalent `ZoneInfo` using the IANA zone name. ZoneInfo behaves like a standard `tzinfo` and handles DST correctly with normal `replace(tzinfo=...)` calls.

2. **`localize_naive(naive_dt, tz)`** - A helper that normalizes the timezone first, then uses standard `replace(tzinfo=...)`.

This approach:
- Centralizes the pytz→ZoneInfo conversion in one place
- Uses standard Python datetime semantics after normalization
- Properly handles DST by letting ZoneInfo interpret wall-clock times correctly
- Avoids pytz-specific API calls scattered throughout the codebase


Fixes #2338
Fixes #2388
Fixes #2391
Fixes #2393
Fixes #2400