### PR TITLE
fix run_at when the next occurrence is tomorrow

### DIFF
--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -2975,7 +2975,9 @@ class ADAPI:
                 _, offset = resolve_time_str(start_str, now=now, location=self.AD.sched.location)
                 func = functools.partial(func, *args, repeat=True, offset=offset)
             case _:
-                start = await self.AD.sched.parse_datetime(start, aware=True)
+                # For run_at, always schedule for the next occurrence (today=False)
+                # This ensures that times in the past are scheduled for tomorrow
+                start = await self.AD.sched.parse_datetime(start, aware=True, today=False)
                 func = functools.partial(
                     self.AD.sched.insert_schedule,
                     name=self.name,

--- a/tests/unit/datetime/test_parse_datetime.py
+++ b/tests/unit/datetime/test_parse_datetime.py
@@ -329,3 +329,46 @@ def test_exact_sun_event(default_date: date, location: Location, tz: BaseTzInfo)
     assert next_sunset.date() != default_date, "Next sunset should be tomorrow"
     assert next_sunset.date() != default_date, "Next sunset should be tomorrow"
     assert next_sunset.date() != default_date, "Next sunset should be tomorrow"
+
+
+def test_run_at_time_in_past(default_now: datetime, default_date: date, tomorrow_date: date, parser: partial[datetime]) -> None:
+    """Test that run_at schedules for next day when time is in the past.
+
+    This test reproduces the bug reported in issue #2491 where run_at() with a time
+    in the past runs immediately instead of scheduling for the next day.
+
+    The fix is to have run_at() explicitly pass today=False to parse_datetime,
+    which forces times in the past to be scheduled for tomorrow.
+    """
+    from datetime import time
+
+    # Current time is 12:00 (default_now is 12:00:00)
+    # Test with a time object that's 1 hour in the past (11:00)
+    past_time = time(11, 0, 0)
+    # run_at should call parse_datetime with today=False
+    result = parser(past_time, today=False)
+
+    # Since the time is in the past and today=False (behavior for run_at),
+    # it should be scheduled for tomorrow
+    assert result.date() == tomorrow_date, f"Expected {tomorrow_date}, got {result.date()}"
+    assert result.time() == past_time
+
+    # Test with a time string that's in the past
+    result_str = parser("11:00:00", today=False)
+    assert result_str.date() == tomorrow_date, f"Expected {tomorrow_date}, got {result_str.date()}"
+
+    # Test with a time that's in the future (should be today)
+    future_time = time(13, 0, 0)
+    result_future = parser(future_time, today=False)
+    assert result_future.date() == default_date, f"Expected {default_date}, got {result_future.date()}"
+    assert result_future.time() == future_time
+
+    # Test with today=True explicitly (should be today even if in the past)
+    result_today = parser(past_time, today=True)
+    assert result_today.date() == default_date
+    assert result_today.time() == past_time
+
+    # Test with today=None (default for elevation events - should be today even if past)
+    result_none = parser(past_time, today=None)
+    assert result_none.date() == default_date
+    assert result_none.time() == past_time


### PR DESCRIPTION
appdaemon 4.3.0b1 in commit fb6a1503c0ac37ade2649000eb6b643c2e1c7c39 ("run_at() support for times that have already passed") introduced a feature to allow run_at to be passed times that have already passed on the current day (so the next occurrence would be tomorrow). And run_daily had always worked that way. It seems like by 4.5.0, this behavior of run_at had been broken in a refactor.

`run_at()` on the latest release executes callbacks immediately when given a time in the past, instead of scheduling them for the next day as documented.

### Problem
When calling `run_at()` with a time that has already passed today, the callback would fire immediately instead of being scheduled for tomorrow:

```python
# At 13:46, this was firing immediately instead of scheduling for tomorrow at 13:45
self.run_at(self.callback, "13:45:00")  

# Same issue with time objects
self.run_at(self.callback, datetime.time(13, 45, 0))
```

This contradicts the documented behavior which states: _"If the time specified is in the past, the callback will occur the next day at the specified time."_

### Root Cause
This is a regression introduced in version 4.5.0 by commit ccf7b18bf177ad982165e470e99fc3de887626cb ("positional argument support and fixed sunrise/sunset calculations").

**Old behavior (pre-4.5.0):**
```python
# run_at explicitly checked if time was in past and added a day
if aware_when < now:
    aware_when += timedelta(days=1)
```

**New behavior (4.5.0+):**
```python
# Delegated to parse_datetime without specifying today parameter
start = await self.AD.sched.parse_datetime(start, aware=True)
# With today=None (default), past times stayed on today's date
```

The refactor delegated time parsing to `parse_datetime()` but didn't explicitly tell it that `run_at()` needs times to always be in the future. The `today` parameter defaults to `None`, which allows times to be in the past (appropriate for elevation events, but not for `run_at()`).

### Solution
Updated `run_at()` to explicitly pass `today=False` when calling `parse_datetime()`:

```python
# For run_at, always schedule for the next occurrence (today=False)
# This ensures that times in the past are scheduled for tomorrow
start = await self.AD.sched.parse_datetime(start, aware=True, today=False)
```


Fixes #2491