### PR TITLE
fix rejected pin value of -1 from init

### DIFF
--- a/appdaemon/app_management.py
+++ b/appdaemon/app_management.py
@@ -527,12 +527,11 @@ class AppManagement:
                     module_name,
                 )
 
-                if (pin := cfg.pin_thread) and pin >= self.AD.threading.total_threads:
+                if (pin := cfg.pin_thread) is not None and pin >= self.AD.threading.total_threads:
                     raise ade.PinOutofRange(pin_thread=pin, total_threads=self.AD.threading.total_threads)
-                elif (obj := self.objects.get(app_name)) and obj.pin_thread is not None:
+                if (obj := self.objects.get(app_name)) and obj.pin_thread is not None:
                     pin = obj.pin_thread
-                else:
-                    pin = -1
+                # else pin is already None from cfg.pin_thread
 
                 # This module should already be loaded and stored in sys.modules
                 mod_obj = await utils.run_in_executor(self, importlib.import_module, module_name)
@@ -585,7 +584,7 @@ class AppManagement:
             type="plugin",
             object=object,
             pin_app=False,
-            pin_thread=-1,
+            pin_thread=None,
             running=False,
         )
 

--- a/appdaemon/callbacks.py
+++ b/appdaemon/callbacks.py
@@ -80,7 +80,7 @@ class Callbacks:
                         )
                         callbacks[name][str(uuid_)]["pin_thread"] = (
                             self.callbacks[name][uuid_]["pin_thread"]
-                            if self.callbacks[name][uuid_]["pin_thread"] != -1
+                            if self.callbacks[name][uuid_]["pin_thread"] is not None
                             else "None"
                         )
         return callbacks

--- a/appdaemon/scheduler.py
+++ b/appdaemon/scheduler.py
@@ -757,7 +757,7 @@ class Scheduler:
                     schedule[name][str(entry)]["callback"] = self.schedule[name][entry]["callback"].func.__name__
                 else:
                     schedule[name][str(entry)]["callback"] = self.schedule[name][entry]["callback"].__name__
-                schedule[name][str(entry)]["pin_thread"] = self.schedule[name][entry]["pin_thread"] if self.schedule[name][entry]["pin_thread"] != -1 else "None"
+                schedule[name][str(entry)]["pin_thread"] = self.schedule[name][entry]["pin_thread"] if self.schedule[name][entry]["pin_thread"] is not None else "None"
                 schedule[name][str(entry)]["pin_app"] = "True" if self.schedule[name][entry]["pin_app"] is True else "False"
 
         # Order it

--- a/appdaemon/threads.py
+++ b/appdaemon/threads.py
@@ -333,7 +333,7 @@ class Threading:
             thread = args["pin_thread"]
             # Handle the case where an App is unpinned but selects a pinned callback without specifying a thread
             # If this happens a lot, thread 0 might get congested but the alternatives are worse!
-            if thread == -1:
+            if thread is None:
                 self.logger.warning(
                     "Invalid thread ID for pinned thread in app: %s - assigning to thread 0",
                     args["name"],
@@ -572,7 +572,7 @@ class Threading:
         thread_pins = [0] * self.pin_threads
         for name, obj in self.AD.app_management.objects.items():
             # Looking for apps that already have a thread pin value
-            if obj.pin_app and (thread := obj.pin_thread) != -1:
+            if obj.pin_app and (thread := obj.pin_thread) is not None:
                 if thread >= self.thread_count:
                     raise ValueError("Pinned thread out of range - check apps.yaml for 'pin_thread' or app code for 'set_pin_thread()'")
                 # Ignore anything outside the pin range as it will have been set by the user
@@ -581,7 +581,7 @@ class Threading:
 
         # Now we know the numbers, go fill in the gaps
         for name, obj in self.AD.app_management.objects.items():
-            if obj.pin_app and obj.pin_thread == -1:
+            if obj.pin_app and obj.pin_thread is None:
                 thread = thread_pins.index(min(thread_pins))
                 self.AD.app_management.set_pin_thread(name, thread)
                 thread_pins[thread] += 1


### PR DESCRIPTION
Use None consistently as the placeholder for the pin value, and never -1, as validate_pin rejects -1 with an exception and can be called before the thread's pin is set:
```
listen_state(callback, entity)  # no pin_thread specified
    → determine_thread(name, None, None)
    → pin_thread = objects[name].pin_thread  # gets -1
    → validate_pin(name, -1)
    → -1 < 0 is True
    → raise PinOutofRange  💥
```

Fixes #2343