### PR TITLE
fix relative_to on internal paths

### DIFF
--- a/appdaemon/exceptions.py
+++ b/appdaemon/exceptions.py
@@ -105,11 +105,14 @@ def user_exception_block(logger: Logger, exception: Exception, app_dir: Path | N
                 logger.error(f"{indent}{exc.__class__.__name__}: {exc}")
                 if tb := traceback.extract_tb(exc.__traceback__):
                     frame = tb[-1]
-                    file = Path(frame.filename).relative_to(app_dir.parent)
-                    logger.error(f"{indent}  line {frame.lineno} in {file.name}")
-                    logger.error(f"{indent}  {frame._line.rstrip()}")
-                    error_len = frame.end_colno - frame.colno
-                    logger.error(f"{indent}  {' ' * (frame.colno - 1)}{'^' * error_len}")
+                    file_path = Path(frame.filename)
+                    # Only show file details if it's in the user's app directory
+                    if file_path.is_relative_to(app_dir.parent):
+                        file = file_path.relative_to(app_dir.parent)
+                        logger.error(f"{indent}  line {frame.lineno} in {file.name}")
+                        logger.error(f"{indent}  {frame._line.rstrip()}")
+                        error_len = frame.end_colno - frame.colno
+                        logger.error(f"{indent}  {' ' * (frame.colno - 1)}{'^' * error_len}")
             case SyntaxError():
                 logger.error(f"{indent}{exc.__class__.__name__}: {exc}")
                 logger.error(f"{indent}  {exc.text.rstrip()}")


### PR DESCRIPTION
If a NameError or ImportError is thrown inside of appdaemon, the relative_to will fail like this:
```
Traceback (most recent call last):
  File "/usr/lib/python3.12/site-packages/appdaemon/utility_loop.py", line 246, in _loop_iteration_context
    yield timing
  File "/usr/lib/python3.12/site-packages/appdaemon/utility_loop.py", line 197, in loop
    await self.AD.app_management.check_app_updates()
  File "/usr/lib/python3.12/site-packages/appdaemon/app_management.py", line 930, in check_app_updates
    await self._create_and_start_apps(update_actions)
  File "/usr/lib/python3.12/site-packages/appdaemon/app_management.py", line 1222, in _create_and_start_apps
    await safe_start(self)
  File "/usr/lib/python3.12/site-packages/appdaemon/exceptions.py", line 182, in wrapper
    user_exception_block(logger, e, app_dir, header)
  File "/usr/lib/python3.12/site-packages/appdaemon/exceptions.py", line 116, in user_exception_block
    file = Path(frame.filename).relative_to(app_dir.parent)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/pathlib.py", line 682, in relative_to
    raise ValueError(f"{str(self)!r} is not in the subpath of {str(other)!r}")
```

This change causes that text to only be appended for exceptions thrown in user app code.

Related to #2457