### PR TITLE
fix copy import for app_management.

### DIFF
--- a/appdaemon/app_management.py
+++ b/appdaemon/app_management.py
@@ -13,7 +13,7 @@ import threading
 import traceback
 from collections import OrderedDict
 from collections.abc import AsyncGenerator, Iterable
-from copy import copy
+import copy
 from functools import partial, reduce, wraps
 from logging import Logger
 from pathlib import Path
@@ -1145,7 +1145,7 @@ class AppManagement:
 
     def _filter_running_apps(self, *trackers: Iterable[str]) -> Iterable[Iterable[str]]:
         """App names that get added to the start order indirectly may already be running."""
-        for app_name in copy(trackers[0]):
+        for app_name in copy.copy(trackers[0]):
             match self.objects.get(app_name):
                 case ManagedObject(running=True):
                     self.logger.debug("Dependent app '%s' is already running", app_name)


### PR DESCRIPTION
I was getting AttributeError: 'function' object has no attribute 'deepcopy' errors when calling the 'app/create' service.

This commit imports the module as that is what is referred to mostly and just adds the module name in one place.

I confirmed the app/create service started working after.