### PR TITLE
Fix get_timezone typing

### DIFF
--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -2678,7 +2678,7 @@ class ADAPI:
         """
         return (await self.get_now(aware=True)).date()
 
-    def get_timezone(self) -> str:
+    def get_timezone(self) -> pytz.tzinfo.BaseTzInfo:
         """Returns the current time zone."""
         return self.AD.time_zone
 

--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -2678,7 +2678,7 @@ class ADAPI:
         """
         return (await self.get_now(aware=True)).date()
 
-    def get_timezone(self) -> pytz.tzinfo.BaseTzInfo:
+    def get_timezone(self) -> dt.tzinfo:
         """Returns the current time zone."""
         return self.AD.time_zone
 


### PR DESCRIPTION
I aligned typing to the current implementation and decided to use `dt.tzinfo` from std lib. Under the hood appdaemon uses BaseTzInfo but this class inherits from  `dt.tzinfo` so it should not be a problem.