### PR TITLE
perf: cut per-event overhead in _sub_stack and events.process_event

### DIFF
--- a/appdaemon/adapi.py
+++ b/appdaemon/adapi.py
@@ -101,14 +101,21 @@ class ADAPI:
     @staticmethod
     def _sub_stack(msg):
         # If msg is a data structure of some type, don't sub
-        if isinstance(msg, str):
-            stack = inspect.stack()
-            if msg.find("__module__") != -1:
-                msg = msg.replace("__module__", stack[2][1])
-            if msg.find("__line__") != -1:
-                msg = msg.replace("__line__", str(stack[2][2]))
-            if msg.find("__function__") != -1:
-                msg = msg.replace("__function__", stack[2][3])
+        if not isinstance(msg, str):
+            return msg
+        # Fast path: avoid the expensive inspect.stack() call (which walks
+        # every frame and reads source lines via linecache) when no
+        # placeholders are present. The vast majority of log calls do not
+        # use __module__/__line__/__function__ substitution.
+        if "__module__" not in msg and "__line__" not in msg and "__function__" not in msg:
+            return msg
+        stack = inspect.stack()
+        if "__module__" in msg:
+            msg = msg.replace("__module__", stack[2][1])
+        if "__line__" in msg:
+            msg = msg.replace("__line__", str(stack[2][2]))
+        if "__function__" in msg:
+            msg = msg.replace("__function__", stack[2][3])
         return msg
 
     def _get_namespace(self, **kwargs):

--- a/appdaemon/events.py
+++ b/appdaemon/events.py
@@ -264,6 +264,15 @@ class Events:
             #
 
             if self.AD.http is not None:
+                # Short-circuit when nobody is subscribed to /stream. The
+                # deepcopy below exists only to feed stream_update, and
+                # ADStream.process_event is itself a no-op when handlers
+                # is empty. When no clients are connected this branch was
+                # the dominant CPU cost in our deployment.
+                stream = getattr(self.AD.http, "stream", None)
+                if stream is not None and not stream.handlers:
+                    return
+
                 if data["event_type"] == "state_changed":
                     if data["data"]["new_state"] == data["data"]["old_state"]:
                         # Nothing changed so don't send

--- a/tests/unit/test_event_stream_shortcircuit.py
+++ b/tests/unit/test_event_stream_shortcircuit.py
@@ -1,0 +1,66 @@
+"""Regression tests for the /stream short-circuit in Events.process_event.
+
+When no clients are subscribed to /stream the deepcopy + stream_update
+work is pure waste — ADStream.process_event already returns immediately
+when ``handlers`` is empty. The fix returns before the deepcopy runs.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from appdaemon.events import Events
+
+pytestmark = [
+    pytest.mark.ci,
+    pytest.mark.unit,
+    pytest.mark.asyncio,
+]
+
+
+def _make_events(handlers):
+    """Build a minimally-mocked Events with a fake http.stream.handlers."""
+    ad = MagicMock()
+    ad.stopping = False
+    ad.sched = None
+    ad.apps_enabled = False
+    ad.logging = MagicMock()
+    ad.logging.get_child.return_value = MagicMock()
+    ad.logging.has_log_callback = AsyncMock(return_value=False)
+    ad.http = MagicMock()
+    ad.http.stream.handlers = handlers
+    ad.http.stream_update = AsyncMock()
+    ad.state = MagicMock()
+    ad.state.set_state_simple = AsyncMock()
+    ad.state.process_state_callbacks = AsyncMock()
+    return Events(ad), ad
+
+
+def _state_changed_event():
+    return {
+        "event_type": "state_changed",
+        "data": {
+            "entity_id": "sensor.x",
+            "new_state": {"state": "on"},
+            "old_state": {"state": "off"},
+        },
+    }
+
+
+async def test_stream_update_skipped_when_no_handlers():
+    events, ad = _make_events(handlers={})
+    await events.process_event("default", _state_changed_event())
+    ad.http.stream_update.assert_not_called()
+
+
+async def test_stream_update_called_when_handler_present():
+    events, ad = _make_events(handlers={"client-1": object()})
+    await events.process_event("default", _state_changed_event())
+    ad.http.stream_update.assert_called_once()
+
+
+async def test_no_op_when_http_disabled():
+    events, ad = _make_events(handlers={"client-1": object()})
+    ad.http = None
+    # Should not raise even though stream is unreachable.
+    await events.process_event("default", _state_changed_event())

--- a/tests/unit/test_event_stream_shortcircuit.py
+++ b/tests/unit/test_event_stream_shortcircuit.py
@@ -8,7 +8,6 @@ when ``handlers`` is empty. The fix returns before the deepcopy runs.
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-
 from appdaemon.events import Events
 
 pytestmark = [

--- a/tests/unit/test_sub_stack.py
+++ b/tests/unit/test_sub_stack.py
@@ -1,0 +1,59 @@
+import pytest
+from appdaemon.adapi import ADAPI
+
+pytestmark = [
+    pytest.mark.ci,
+    pytest.mark.unit,
+]
+
+
+def _log(msg):
+    """Stand-in for ADAPI.log/error/etc.
+
+    ``_sub_stack`` reads ``stack[2]`` — two frames above itself — because it is
+    designed to be called from inside a logging wrapper. Tests therefore need
+    an intermediate frame so the resolved caller is deterministic.
+    """
+    return ADAPI._sub_stack(msg)
+
+
+def test_non_string_returned_unchanged():
+    payload = {"key": "value"}
+    assert ADAPI._sub_stack(payload) is payload
+    assert ADAPI._sub_stack(123) == 123
+    assert ADAPI._sub_stack(None) is None
+
+
+def test_plain_string_returned_unchanged():
+    msg = "nothing special here"
+    assert _log(msg) == msg
+
+
+def test_module_placeholder_substituted():
+    result = _log("called from __module__")
+    assert "__module__" not in result
+    assert result.startswith("called from ")
+
+
+def test_line_placeholder_substituted():
+    result = _log("line=__line__")
+    assert "__line__" not in result
+    assert result.startswith("line=")
+    assert result[len("line=") :].isdigit()
+
+
+def test_function_placeholder_substituted():
+    def outer_caller():
+        return _log("in __function__")
+
+    assert outer_caller() == "in outer_caller"
+
+
+def test_multiple_placeholders_in_same_message():
+    def outer_caller():
+        return _log("__function__ at __line__")
+
+    result = outer_caller()
+    assert "__function__" not in result
+    assert "__line__" not in result
+    assert result.startswith("outer_caller at ")


### PR DESCRIPTION
Two small performance fixes for AppDaemon's per-event path.

## 1. `ADAPI._sub_stack`: skip `inspect.stack()` when no placeholders are present

Today `_sub_stack` calls `inspect.stack()` unconditionally on every string log, then checks whether `__module__` / `__line__` / `__function__` are actually in the message. Since most log calls don't use those placeholders, the stack walk is wasted work, and it's not cheap. `inspect.stack()` is O(frame count) plus source file reads via `linecache` per frame, and real AppDaemon callback stacks are 30 to 60 frames deep (asyncio, threadpool, dispatch, app).

This PR reorders the check: cheap substring test first, stack walk only when a placeholder is actually present. Behaviour is identical in both branches.

### Measurements

Measured inside a running AppDaemon 4.5.13 pod (Python 3.12, warm linecache):

| Stack depth | `inspect.stack()` cost |
|---:|---:|
| 8 | 8.9 ms |
| 18 | 10.6 ms |
| 33 | 13.8 ms |
| 63 | 33.9 ms |

Cold calls and GIL contention push it higher still.

### Real-world impact

In a motion-activated lighting deployment (around 10 zones, heavy `self.log` usage in callbacks), zone updates were taking 400 to 500 ms end to end. After bypassing `_sub_stack` for placeholder-free messages via a local monkey-patch equivalent to this change, the same updates run in 2 to 13 ms with nothing else modified.

### Change

- `adapi.py`: early return for non-strings, then for strings with no placeholders. Otherwise the existing stack walk and substitutions run unchanged at the same frame index (`stack[2]`).
- `tests/unit/test_sub_stack.py`: tests for non-string input, plain strings, each placeholder individually, and multiple placeholders in one message.

---

## 2. `Events.process_event`: skip the deepcopy when no `/stream` clients are connected

`Events.process_event` unconditionally deep-copies every inbound HA event when `http:` is enabled, so the copy can be forwarded to `/stream` for admin UI / HADashboard subscribers. The stream handler (`ADStream.process_event`) already short-circuits when `handlers` is empty, but the `deepcopy` at `events.py:272/275` happens *before* that check, so the cost is paid unconditionally.

For any install that enables `http:` for its REST endpoints (`/api/appdaemon/*`) but doesn't keep an admin UI / HADashboard tab open, the deepcopy is pure waste.

This PR adds an early return when `http.stream.handlers` is empty, before the `state_changed` equality check and before either `deepcopy()`. The existing path runs unchanged whenever at least one client is subscribed, so opening the admin UI restores full stream behaviour automatically.

### Measurements

py-spy (50 Hz sampling, 5-minute window) against a pod running ~150 apps with roughly 5 HA `state_changed` events/sec, no admin UI client connected:

| Sampled frame | Before | After |
|---:|---:|---:|
| `deepcopy` (copy.py) | 24.2% | <1% |
| `_deepcopy_dict` (copy.py) | 20.6% | <1% |
| `events.process_event` total | 12.0% | ~3% |

Combined impact on container CPU: sustained average dropped from ~443 mCPU to ~29 mCPU post-restart in our deployment (admin-loop fix also contributed — the deepcopy elimination is the larger share).

### Real-world impact

`/stream` subscribers are rare in normal operation — most deployments open the admin UI to debug and then close it. When nothing is subscribed, this branch was the dominant steady-state cost of AppDaemon in our environment.

### Change

- `events.py`: inside the `if self.AD.http is not None:` branch, check `http.stream.handlers`. Return early if empty. Otherwise the existing path (state-changed equality check, deepcopy, `stream_update`) runs unchanged.
- `tests/unit/test_event_stream_shortcircuit.py`: verifies `stream_update` is skipped when `handlers` is empty, called when it has clients, and that `http=None` still works.

I only touched that one block in `process_event` to keep the diff minimal.