### PR TITLE
Fix fan widget speeds

### DIFF
--- a/appdaemon/widgets/basefan/basefan.js
+++ b/appdaemon/widgets/basefan/basefan.js
@@ -75,17 +75,17 @@ function basefan(widget_id, url, skin, parameters)
 
     function On1ButtonClick(self) {
         args = self.parameters.post_service_speed;
-        args["speed"] = self.parameters.fields.low_speed;
+        args["percentage"] = self.parameters.fields.low_speed;
         self.call_service(self, args);
     }
     function On2ButtonClick(self) {
         args = self.parameters.post_service_speed;
-        args["speed"]= self.parameters.fields.medium_speed;
+        args["percentage"]= self.parameters.fields.medium_speed;
         self.call_service(self, args);
     }
     function On3ButtonClick(self) {
         args = self.parameters.post_service_speed;
-        args["speed"] = self.parameters.fields.high_speed;
+        args["percentage"] = self.parameters.fields.high_speed;
         self.call_service(self, args);
     }
 
@@ -112,7 +112,7 @@ function basefan(widget_id, url, skin, parameters)
             self.set_field(self, "icon_style", self.css.icon_style_active)
 
             //decide which icon to mark as selected
-            if (state.attributes.speed == self.parameters.fields.low_speed){
+            if (state.attributes.percentage == self.parameters.fields.low_speed){
                 self.set_field(self,"speed1_style", self.css.speed1_style_active)
                 self.set_field(self,"speed2_style", self.css.speed2_style_inactive)
                 self.set_field(self,"speed3_style", self.css.speed3_style_inactive)
@@ -120,7 +120,7 @@ function basefan(widget_id, url, skin, parameters)
                 self.set_icon(self, "icon2", self.icons.icon2_inactive)
                 self.set_icon(self, "icon3", self.icons.icon3_inactive)
             }
-            else if (state.attributes.speed == self.parameters.fields.medium_speed){
+            else if (state.attributes.percentage == self.parameters.fields.medium_speed){
                 self.set_field(self,"speed1_style", self.css.speed1_style_inactive)
                 self.set_field(self,"speed2_style", self.css.speed2_style_active)
                 self.set_field(self,"speed3_style", self.css.speed3_style_inactive)
@@ -128,7 +128,7 @@ function basefan(widget_id, url, skin, parameters)
                 self.set_icon(self, "icon2", self.icons.icon2_active)
                 self.set_icon(self, "icon3", self.icons.icon3_inactive)
             }
-            else if (state.attributes.speed == self.parameters.fields.high_speed){
+            else if (state.attributes.percentage == self.parameters.fields.high_speed){
                 self.set_field(self,"speed1_style", self.css.speed1_style_inactive)
                 self.set_field(self,"speed2_style", self.css.speed2_style_inactive)
                 self.set_field(self,"speed3_style", self.css.speed3_style_active)

--- a/appdaemon/widgets/fan.yaml
+++ b/appdaemon/widgets/fan.yaml
@@ -1,7 +1,7 @@
 widget_type: basefan
 entity: "{{entity}}"
 post_service_speed:
-    service: fan/set_speed
+    service: fan/set_percentage
     entity_id: "{{entity}}"
 post_service_active:
     service: fan/turn_on
@@ -19,9 +19,9 @@ fields:
   icon1: ""
   icon2: ""
   icon3: ""
-  low_speed: "low"
-  medium_speed: "medium"
-  high_speed: "high"
+  low_speed: 33
+  medium_speed: 66
+  high_speed: 100
 icons:
   icon_active: $fan_icon_on
   icon_inactive: $fan_icon_off


### PR DESCRIPTION
Home Assistant 2021.3 introduced a new service `fan.set_percentage` to replace the old `fan.set_speed`. I'm not sure if they removed `set_speed` immediately, but it is already missing on my system (2026.3.4), causing the speed buttons on the fan card in HADashboard to not work.
This patch migrates to the new service (and thus breaks compatibility with pre-2021.3 HA).