### PR TITLE
fix: handle empty POST body

### DIFF
--- a/appdaemon/http.py
+++ b/appdaemon/http.py
@@ -965,7 +965,7 @@ class HTTP:
 
             if request.method == "POST":
                 try:
-                    args = await request.json()
+                    args = await request.json() if request.can_read_body else null
                 except json.decoder.JSONDecodeError:
                     return self.get_response(request, 400, "JSON Decode Error")
             else:


### PR DESCRIPTION
This will handle the edge case of having an empty body on a POST request. Notable example is the location service for the firefox browser. Fixes #2611 